### PR TITLE
✨  feat: add configurable CHANNAME parameter; fix CallBarcodes column for cpg0032

### DIFF
--- a/assets/cp0032_test_cppipes/9_Analysis.cppipe
+++ b/assets/cp0032_test_cppipes/9_Analysis.cppipe
@@ -673,7 +673,7 @@ CallBarcodes:[module_num:41|svn_version:'Unknown'|variable_revision_number:1|sho
     Input data file location:Default Input Folder|C:\Users\Administrator\Desktop\metadata\20200805_A549_WG_Screen
     Name of the file:Barcodes.csv
     Select the column of barcodes to match against:Barcode
-    Select the column with gene/transcript barcode names:Construct
+    Select the column with gene/transcript barcode names:Gene
     Retain an image of the barcodes color coded by call?:Yes
     Enter the called barcode image name:Barcodes_IntValues
     Retain an image of the barcodes color coded by score match?:Yes

--- a/assets/stitchcrop/stitch_crop.env_master.py
+++ b/assets/stitchcrop/stitch_crop.env_master.py
@@ -107,11 +107,12 @@ if os.path.isdir(subdir):
         presuflist.sort()
         print welllist, presuflist
 
-        # Fallback: if no channel matched channame, use the first available prefix/suffix
-        if permprefix is None and len(presuflist) > 0:
-                permprefix = presuflist[0][0]
-                permsuffix = presuflist[0][1]
-                print("Warning: CHANNAME '"+channame+"' not found in any file. Using first available channel: "+permsuffix)
+        # Error if no channel matched channame - requires explicit CHANNAME configuration
+        if permprefix is None:
+                print("ERROR: CHANNAME '"+channame+"' not found in any file.")
+                print("Available channels: " + str([ps[1] for ps in presuflist]))
+                print("Set CHANNAME environment variable to match one of the available channels.")
+                sys.exit(1)
 
         if round_or_square == 'square':
                 stitchedsize=int(rows)*int(size)

--- a/conf/test_cpg0032.config
+++ b/conf/test_cpg0032.config
@@ -61,6 +61,7 @@ params {
     painting_scalingstring      = 2
     painting_imperwell          = "256"
     painting_stitchorder        = "Grid: snake by rows"
+    painting_channame           = "DNA"
 
     // Stitching/Cropping parameters - Barcoding-specific
     barcoding_round_or_square   = "round"
@@ -69,6 +70,7 @@ params {
     barcoding_scalingstring     = 2
     barcoding_imperwell         = "56"
     barcoding_stitchorder       = "Grid: snake by rows"
+    barcoding_channame          = "DAPI"
 
     tileperside                 = 5
     final_tile_size             = 5500

--- a/modules/local/fiji/stitchcrop/main.nf
+++ b/modules/local/fiji/stitchcrop/main.nf
@@ -21,6 +21,7 @@ process FIJI_STITCHCROP {
     val xoffset_tiles
     val yoffset_tiles
     val compress
+    val channame
     val should_run
 
     output:
@@ -65,6 +66,7 @@ process FIJI_STITCHCROP {
     export XOFFSET_TILES="${xoffset_tiles}"
     export YOFFSET_TILES="${yoffset_tiles}"
     export COMPRESS="${compress}"
+    export CHANNAME="${channame}"
     export FIRST_SITE_INDEX="${first_site_index}"
 
     # Run Fiji in headless mode

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,7 @@ params {
     painting_stitchorder          = "Grid: snake by rows"
     painting_xoffset_tiles        = 0
     painting_yoffset_tiles        = 0
+    painting_channame             = "DNA"
 
     // Stitching/Cropping parameters - Barcoding-specific
     barcoding_round_or_square     = "round"
@@ -47,6 +48,7 @@ params {
     barcoding_stitchorder         = "Grid: snake by rows"
     barcoding_xoffset_tiles       = 0
     barcoding_yoffset_tiles       = 0
+    barcoding_channame            = "DNA"
 
     // Stitching/Cropping parameters - Shared between painting and barcoding
     tileperside                   = 10

--- a/subworkflows/local/barcoding/main.nf
+++ b/subworkflows/local/barcoding/main.nf
@@ -41,6 +41,7 @@ workflow BARCODING {
     barcoding_xoffset_tiles
     barcoding_yoffset_tiles
     compress
+    barcoding_channame
     qc_barcoding_passed
 
     main:
@@ -359,6 +360,7 @@ workflow BARCODING {
         barcoding_xoffset_tiles,
         barcoding_yoffset_tiles,
         compress,
+        barcoding_channame,
         qc_barcoding_passed,
     )
 

--- a/subworkflows/local/cellpainting/main.nf
+++ b/subworkflows/local/cellpainting/main.nf
@@ -33,6 +33,7 @@ workflow CELLPAINTING {
     painting_xoffset_tiles
     painting_yoffset_tiles
     compress
+    painting_channame
     qc_painting_passed
 
     main:
@@ -280,6 +281,7 @@ workflow CELLPAINTING {
         painting_xoffset_tiles,
         painting_yoffset_tiles,
         compress,
+        painting_channame,
         qc_painting_passed,
     )
 

--- a/workflows/nf-pooled-cellpainting.nf
+++ b/workflows/nf-pooled-cellpainting.nf
@@ -74,6 +74,7 @@ workflow POOLED_CELLPAINTING {
         params.painting_xoffset_tiles,
         params.painting_yoffset_tiles,
         params.compress,
+        params.painting_channame,
         params.qc_painting_passed,
     )
     ch_versions = ch_versions.mix(CELLPAINTING.out.versions)
@@ -107,6 +108,7 @@ workflow POOLED_CELLPAINTING {
         params.barcoding_xoffset_tiles,
         params.barcoding_yoffset_tiles,
         params.compress,
+        params.barcoding_channame,
         params.qc_barcoding_passed,
     )
     ch_versions = ch_versions.mix(BARCODING.out.versions)


### PR DESCRIPTION
## Summary

- Add `painting_channame` and `barcoding_channame` parameters to configure the reference channel used for stitching tile registration
- This allows different datasets to use different channel naming conventions (e.g., DNA vs DAPI) without modifying CellProfiler pipelines
- Fix `CallBarcodes` column name from `Construct` to `Gene` in pipeline 9 for cpg0032 dataset

## Changes

- Add `channame` input parameter to `FIJI_STITCHCROP` module and export as environment variable
- Wire parameters through `cellpainting` and `barcoding` subworkflows
- Add defaults in `nextflow.config` (both default to `"DNA"`)
- Configure cpg0032 test profile: `painting_channame="DNA"`, `barcoding_channame="DAPI"`
- Convert silent fallback in `stitch_crop.env_master.py` to explicit error with list of available channels
- Update `9_Analysis.cppipe` to use `Gene` column instead of `Construct` for cpg0032 Barcodes.csv

## Context

**CHANNAME issue:** The stitch_crop script already supported `CHANNAME` configuration via environment variable, but it wasn't exposed through the Nextflow pipeline. The cpg0032 dataset uses `DAPI` naming in the barcoding preprocess output (from pipeline 7), which caused stitching to silently use the wrong reference channel (falling back to the first available channel).

**Original behavior:** The original stitch_crop script (and pcpip's stitch_crop_v0.py) had no fallback logic. If `CHANNAME` didn't match any file, `permprefix` would remain `None` and the script would crash with `TypeError: cannot concatenate 'str' and 'NoneType'`. The fallback to first available channel was added later as a hotfix (commit 2488c1f), but this silently used the wrong reference channel. This PR replaces that silent fallback with an explicit error message listing available channels.

**CallBarcodes column issue:** The cpg0032 Barcodes.csv uses `Gene` as the column name, but pipeline 9 was configured to look for `Construct`. It's unclear why this ever worked in the past, but this fix is definitely needed. Note that pipeline 7 was not affected as it correctly picks the right column.

## Design decisions

**Alternative considered:** We could have modified `7_BC_Preprocess.cppipe` to output `DNA` instead of `DAPI`. However, we chose to properly expose the existing `CHANNAME` configuration through the Nextflow layer instead. This demonstrates the pipeline's flexibility for different naming conventions without requiring CellProfiler pipeline modifications.

**Explicit configuration:** In `test_cpg0032.config`, we explicitly set `painting_channame="DNA"` even though it matches the default. This makes the configuration self-documenting and parallel to the barcoding setting.

**No reliance on channel ordering:** The previous fallback behavior silently used the first available channel when CHANNAME didn't match, which is incorrect and unreliable. The new implementation requires explicit configuration and fails fast with a helpful error message listing available channels.

## Test plan

- [ ] Run pipeline with cpg0032 test profile to verify barcoding stitching uses DAPI channel
- [ ] Run pipeline with default config to verify DNA channel is used
- [ ] Verify error message appears when CHANNAME doesn't match any files

🤖 Generated with [Claude Code](https://claude.com/claude-code)