### PR TITLE
Phenix end to end

### DIFF
--- a/assets/stitchcrop/stitch_crop.env_master.py
+++ b/assets/stitchcrop/stitch_crop.env_master.py
@@ -10,7 +10,6 @@ columns = os.getenv("COLUMNS", "2")
 imperwell = os.getenv("IMPERWELL", "")
 stitchorder = os.getenv("STITCHORDER", "Grid: snake by rows")
 channame = os.getenv("CHANNAME", "DNA")
-size = os.getenv("SIZE", "1480")
 overlap_pct = os.getenv("OVERLAP_PCT", "10")
 tileperside = os.getenv("TILEPERSIDE", "2")
 filterstring = os.getenv("FILTERSTRING", "")
@@ -25,7 +24,7 @@ final_tile_size = os.getenv("FINAL_TILE_SIZE", "2960")
 xoffset_tiles = os.getenv("XOFFSET_TILES", "0")
 yoffset_tiles = os.getenv("YOFFSET_TILES", "0")
 compress = os.getenv("COMPRESS", "True")
-first_site_index = os.getenv("FIRST_SITE_INDEX", "0")
+phenix = os.getenv("PHENIX","False")
 
 from ij import IJ, WindowManager
 import os
@@ -36,6 +35,89 @@ import time
 from loci.plugins.out import Exporter
 from loci.plugins import LociExporter
 plugin = LociExporter()
+
+#Dict of well sizes we understand for well-patterns that start in the top left and snake towards the right and bottom
+im_per_well_dict = {
+    "1396": [
+        18, 22, 26, 28, 30, 32, 34, 36, 36, 38, 38, 40, 40, 40, 40, 40, 40, 40, 40, 40, 
+        40, 40, 40, 40, 40, 40, 40, 40, 40, 38, 38, 36, 36, 34, 32, 30, 28, 26, 22, 18,
+    ],
+    "1364": [8, 14, 18, 22, 26, 28, 30, 32, 34, 34, 36, 36, 38, 38, 40, 40, 40, 42, 42,
+        42, 42, 42, 42, 42, 42, 40, 40, 40, 38, 38, 36, 36, 34, 34, 32, 30, 28, 26, 22, 
+        18, 14, 8,
+    ],
+    "1332": [
+        14, 18, 22, 26, 28, 30, 32, 34, 34, 36, 36, 38, 38, 40, 40, 40, 40, 40, 40, 40,
+        40, 40, 40, 40, 40, 40, 40, 38, 38, 36, 36, 34, 34, 32, 30, 28, 26, 22, 18, 14,
+    ],
+    "1025":[
+        5,11,17,19,23,25,27,29,29,31,33,33,33,35,35,35,37,37,37,37,37,35,35,35,33,
+        33,33,31,29,29,27,25,23,19,17,11,5,
+    ],
+    "394": [
+        3, 7, 9, 11, 11, 13, 13, 15, 15, 15, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+        15, 15, 15, 13, 13, 11, 11, 9, 7, 3,
+    ],
+    "320": [
+        4, 8, 12, 14, 16, 18, 18, 20, 20, 20, 20, 20, 20, 20, 18, 18, 16, 14, 12, 8, 
+        4,
+    ],
+    "316": [6, 10, 14, 16, 16, 18, 18, 20, 20, 20, 20, 20, 20, 18, 18, 16, 16, 14, 10, 6],
+    "293": [7, 11, 13, 15, 17, 17, 19, 19, 19, 19, 19, 19, 19, 17, 17, 15, 13, 11, 7],
+    "256": [6, 10, 12, 14, 16, 16, 18, 18, 18, 18, 18, 18, 16, 16, 14, 12, 10, 6],
+    "88": [6, 8, 10, 10, 10, 10, 10, 10, 8, 6],
+    "56": [2, 6, 8, 8, 8, 8, 8, 6, 2],
+    "52": [4, 6, 8, 8, 8, 8, 6, 4],
+    "45": [5,7,7,7,7,7,5],
+}
+
+#Dict of well sizes we understand for well-patterns that start in the center, then jump to the top left and snake 
+#towards the right and bottom. As far as we know, this is just the Phenix (and friends like the Operetta)
+phenix_im_per_well_dict = {
+    "80": [['']*3+list(range(2,6))+['']*3,
+            ['']+list(range(13,5,-1))+[''],
+            ['']+list(range(14,22))+[''],
+            list(range(31,21,-1)),
+            list(range(32,42)),
+            list(range(50,46,-1))+[1]+list(range(46,41,-1)),
+            list(range(51,61)),
+            ['']+list(range(68,60,-1))+[''],
+            ['']+list(range(69,77))+[''],
+            ['']*3+list(range(80,76,-1))+['']*3,
+            ],
+    "21": [['']+list(range(2,5))+[''],
+            list(range(9,4,-1)),
+            list(range(10,12))+[1]+list(range(12,14)),
+            list(range(18,13,-1)),
+            ['']+list(range(19,22))+[''],
+            ]
+}
+
+#This carries the per-quarter variable options for stitching in quarters
+#It is prepopulated with anything we know that's size-agnostic; size-dependent
+#parameters are calculated and added by determine_final_tile_size_and_offsets
+stitched_quarter_dict = {"TopLeft":
+                         {"name":"StitchedTopLeft",
+                          "position":"Bottom-Right zero",
+                          "tile_coords_for_final_tiles":{}
+                         },
+                        "TopRight":
+                        {"name":"StitchedTopRight",
+                          "position":"Bottom-Left zero", 
+                          "tile_coords_for_final_tiles":{}
+                         },
+                        "BotLeft":
+                        {"name":"StitchedBottomLeft",
+                          "position":"Top-Right zero", 
+                          "tile_coords_for_final_tiles":{}
+                         },
+                        "BotRight":
+                        {"name":"StitchedBottomRight",
+                          "position":"Top-Left zero", 
+                          "tile_coords_for_final_tiles":{}
+                         },
+                        }
+
 
 def tiffextend(imname):
         if '.tif' in imname:
@@ -63,6 +145,715 @@ def savefile(im,imname,plugin,compress='false'):
                                 attemptcount +=1
                 print('failed 5 times at saving')
 
+
+def parse_files(subdir, channame, filterstring):
+    """
+    Figure out the wells present and channels present in our data, therefore what we should stitch
+    Right now, assumes all output comes from our nice CellProfiler pipelines upstream
+    Future versions where barcoding comes off the microscope (or phenotyping, for a scope
+    where on-scope FFC is good) will need new and better parsing"""
+    dir_list = os.listdir(subdir)
+    well_list = []
+    prefix_suffix_list = []
+    perm_prefix = None
+    perm_suffix = None
+    for eachfile in dir_list:
+        if ".tif" in eachfile:
+            if filterstring in eachfile:
+                if "Overlay" not in eachfile:
+                    prefix_before_well, suffix_with_well = eachfile.split("_Well_")
+                    well, suffix_after_well = suffix_with_well.split("_Site_")
+                    channel_suffix = suffix_after_well[suffix_after_well.index("_") + 1 :]
+                    if (prefix_before_well, channel_suffix) not in prefix_suffix_list:
+                        prefix_suffix_list.append((prefix_before_well, channel_suffix))
+                    if well not in well_list:
+                        well_list.append(well)
+                    if channame in channel_suffix:
+                        if perm_prefix is None:
+                            perm_prefix = prefix_before_well
+                            perm_suffix = channel_suffix
+
+    for eachpresuf in prefix_suffix_list:
+        if eachpresuf[1][-4:] != ".tif":
+            if eachpresuf[1][-5:] != ".tiff":
+                prefix_suffix_list.remove(eachpresuf)
+    prefix_suffix_list.sort()
+    print("final parse results", well_list, prefix_suffix_list)
+    if perm_prefix is None or perm_suffix is None:
+        print("Something went wrong with parsing, couldn't find files with the channel name", channame)
+        print("Can also be caused by your filterstring", filterstring, "removing all files")
+        print("Can also be caused if images are not .tif or .tiff")
+        sys.exit()
+    return dir_list, well_list,prefix_suffix_list, perm_prefix, perm_suffix
+    
+def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
+                                 perm_prefix, eachwell, perm_suffix, compress, 
+                                 out_subdir, plugin, stitched_quarter_dict, quarter = False,):
+    """Actually does the initial stitching, outputs the Tile Configuration file, no Python return.
+    Could probably be refactored/shortened even further but it's probably fine."""
+    if round_or_square == 'square':
+        standard_grid_instructions = [
+            "type=["
+            + stitchorder
+            + "] order=[Right & Down                ] grid_size_x="
+            + rows
+            + " grid_size_y="
+            + columns
+            + " tile_overlap="
+            + overlap_pct
+            + " first_file_index_i=0 directory="
+            + subdir
+            + " file_names=",
+            " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]",
+        ]
+        filename = perm_prefix + "_Well_" + eachwell + "_Site_{i}_" + perm_suffix
+        fileoutname = "Stitched" + filename.replace("{i}", "")
+        IJ.run(
+            "Grid/Collection stitching",
+            standard_grid_instructions[0]
+            + filename
+            + standard_grid_instructions[1],
+        )
+        im = IJ.getImage()
+        # We're going to overwrite this file later, but it gives is a chance for an early checkpoint
+        # This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
+        if compress.lower() != "true":
+            savefile(
+                im, os.path.join(out_subdir, fileoutname), plugin, compress=compress
+            )
+        IJ.run("Close All")
+    else:
+        if quarter_if_round.lower() == "false":
+            standard_grid_instructions = [
+                "type=[Filename defined position] order=[Defined by filename         ] grid_size_x="
+                + str(columns)
+                + " grid_size_y="
+                + str(rows)
+                + " tile_overlap="
+                + overlap_pct
+                + " first_file_index_x=0 first_file_index_y=0 directory="
+                + subdir
+                + " file_names=",
+                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]",
+            ]
+            filename = (
+                perm_prefix + "_Well_" + eachwell + "_x_{xx}_y_{yy}_" + perm_suffix
+            )
+            fileoutname = "Stitched" + filename.replace("{i}", "")
+            instructions = (
+                standard_grid_instructions[0]
+                + filename
+                + standard_grid_instructions[1]
+            )
+            print(instructions)
+            IJ.run("Grid/Collection stitching", instructions)
+            im = IJ.getImage()
+            # We're going to overwrite this file later, but it gives us a chance for an early checkpoint
+            # This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
+            if compress.lower() != "true":
+                savefile(
+                    im,
+                    os.path.join(out_subdir, fileoutname),
+                    plugin,
+                    compress=compress,
+                )
+            print(os.path.join(out_subdir, fileoutname))
+            time.sleep(30)
+            IJ.run("Close All")
+        else:
+            quarter_options = stitched_quarter_dict[quarter]
+            print(quarter_options)
+            standard_grid_instructions = [
+                "type=[Filename defined position] order=[Defined by filename         ] grid_size_x="
+                + quarter_options["grid_size_x"]
+                + " grid_size_y="
+                + quarter_options["grid_size_y"]
+                + " tile_overlap="
+                + overlap_pct
+                + " first_file_index_x="
+                + str(quarter_options["first_file_index_offset_x"])
+                +" first_file_index_y="
+                + str(quarter_options["first_file_index_offset_y"])
+                +" directory="
+                + os.path.abspath(subdir)
+                + " file_names=",
+                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]",
+            ]
+            filename = (
+                perm_prefix + "_Well_" + eachwell + "_x_{xx}_y_{yy}_" + perm_suffix
+            )
+            fileoutname = quarter_options["name"] + filename.replace("{xx}", "").replace(
+                "{yy}", ""
+            )
+            instructions = (
+                standard_grid_instructions[0]
+                + filename
+                + standard_grid_instructions[1]
+            )
+            print(instructions)
+            IJ.run("Grid/Collection stitching", instructions)
+            im = IJ.getImage()
+            # We're going to overwrite this file later, but it gives us a chance for an early checkpoint
+            # This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
+            if compress.lower() != "true":
+                savefile(
+                    im,
+                    os.path.join(out_subdir, fileoutname),
+                    plugin,
+                    compress=compress,
+                )
+            IJ.run("Close All")
+
+def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
+                                          stitched_quarter_dict, compress, quarter = False, emptylist=None,  upscaled_row_size=0, upscaled_col_size=0):
+    """Apply the stitching pattern calculated in run_initial_stitching_per_well to each channel for this well (or well quarter).
+    For round wells where we've padded with noise tiles, uses the emptylist to remove them from the final configuration file we pass
+    to the Grid/Stitch plugin, avoiding a very old bug that just dumps them on the top-left real tile.
+    We make a full-sized stitch and a 10x downsampled stitch (for easy QC), then close everything and re-open the full-sized stitch
+    to create a set of sub-tiled crops"""
+    copy_grid_instructions = (
+            "type=[Positions from file] order=[Defined by TileConfiguration] directory="
+            + subdir
+            + " layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
+        )
+    
+    #set up
+    if round_or_square == 'square':
+            do_quarter = False
+    else:
+        if quarter_if_round.lower()== "true":
+            do_quarter = True
+        else:
+            do_quarter = False
+    if not do_quarter:
+        thisprefix, thissuffix = eachpresuf
+        thissuffixnicename = thissuffix.split(".")[0]
+        if thissuffixnicename[0] == "_":
+            thissuffixnicename = thissuffixnicename[1:]
+        tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
+        if not os.path.exists(tile_subdir_persuf):
+            os.mkdir(tile_subdir_persuf)
+        filename = thisprefix + "_Well_" + eachwell + "_Site_{i}_" + thissuffix
+        fileoutname = "Stitched" + filename.replace("{i}", "")
+        with open(
+            os.path.join(subdir, "TileConfiguration.registered.txt"), "r"
+        ) as infile:
+            with open(
+                os.path.join(subdir, "TileConfiguration.registered_copy.txt"),
+                "w",
+            ) as outfile:
+                for line in infile:
+                    if emptylist is not None:
+                        if not any([empty in line for empty in emptylist]):
+                            line = line.replace(perm_prefix, thisprefix)
+                            line = line.replace(perm_suffix, thissuffix)
+                            outfile.write(line)
+                    else:
+                        line = line.replace(perm_prefix, thisprefix)
+                        line = line.replace(perm_suffix, thissuffix)
+                        outfile.write(line)
+
+        IJ.run("Grid/Collection stitching", copy_grid_instructions)
+        im = IJ.getImage()
+        width = str(int(round(im.width * float(scalingstring))))
+        height = str(int(round(im.height * float(scalingstring))))
+        # scale the barcoding and cell painting images to match each other
+        print(
+            "Scale...",
+            "x="
+            + scalingstring
+            + " y="
+            + scalingstring
+            + " width="
+            + width
+            + " height="
+            + height
+            + " interpolation=Bilinear average create",
+        )
+        IJ.run(
+            "Scale...",
+            "x="
+            + scalingstring
+            + " y="
+            + scalingstring
+            + " width="
+            + width
+            + " height="
+            + height
+            + " interpolation=Bilinear average create",
+        )
+        time.sleep(15)
+        im2 = IJ.getImage()
+        # padding to ensure tiles are all the same size (for CellProfiler later on)
+        print(
+            "Canvas Size...",
+            "width="
+            + str(upscaled_col_size)
+            + " height="
+            + str(upscaled_row_size)
+            + " position=Top-Left zero",
+        )
+        IJ.run(
+            "Canvas Size...",
+            "width="
+            + str(upscaled_col_size)
+            + " height="
+            + str(upscaled_row_size)
+            + " position=Top-Left zero",
+        )
+        time.sleep(15)
+        im3 = IJ.getImage()
+        savefile(
+            im3,
+            os.path.join(out_subdir, fileoutname),
+            plugin,
+            compress=compress,
+        )
+        im = IJ.getImage()
+        # scaling to make a downsampled image for QC
+        print(
+            "Scale...",
+            "x=0.1 y=0.1 width="
+            + str(im.width / 10)
+            + " height="
+            + str(im.width / 10)
+            + " interpolation=Bilinear average create",
+        )
+        im_10 = IJ.run(
+            "Scale...",
+            "x=0.1 y=0.1 width="
+            + str(im.width / 10)
+            + " height="
+            + str(im.width / 10)
+            + " interpolation=Bilinear average create",
+        )
+        im_10 = IJ.getImage()
+        savefile(
+            im_10,
+            os.path.join(downsample_subdir, fileoutname),
+            plugin,
+            compress=compress,
+        )
+        IJ.run("Close All")
+        im = IJ.open(os.path.abspath(os.path.join(out_subdir, fileoutname)))
+        im = IJ.getImage()
+        plate = fileoutname.split("Plate_")[1].split("_Well_")[0]
+        for eachxtile in range(int(tileperside)):
+            for eachytile in range(int(tileperside)):
+                each_tile_num = eachxtile * int(tileperside) + eachytile + 1
+                IJ.makeRectangle(
+                    eachxtile * tilesize,
+                    eachytile * tilesize,
+                    tilesize,
+                    tilesize,
+                )
+                im_tile = im.crop()
+                savefile(
+                    im_tile,
+                    os.path.join(
+                        tile_subdir_persuf,
+                        thissuffixnicename
+                        + "_Plate_"
+                        + str(plate)
+                        + "_Well_"
+                        + str(eachwell)
+                        + "_Site_"
+                        + str(each_tile_num)
+                        + ".tiff",
+                    ),
+                    plugin,
+                    compress=compress,
+                )
+        IJ.run("Close All")
+    else:
+        quarter_options = stitched_quarter_dict[quarter]
+        thisprefix, thissuffix = eachpresuf
+        thissuffixnicename = thissuffix.split(".")[0]
+        if thissuffixnicename[0] == "_":
+            thissuffixnicename = thissuffixnicename[1:]
+        tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
+        if not os.path.exists(tile_subdir_persuf):
+            os.mkdir(tile_subdir_persuf)
+        filename = (
+            thisprefix
+            + "_Well_"
+            + eachwell
+            + "_x_{xx}_y_{yy}_"
+            + thissuffix
+        )
+        fileoutname = quarter_options["name"] + filename.replace(
+            "{xx}", ""
+        ).replace("{yy}", "")
+        with open(
+            os.path.join(subdir, "TileConfiguration.registered.txt"), "r"
+        ) as infile:
+            with open(
+                os.path.join(
+                    subdir, "TileConfiguration.registered_copy.txt"
+                ),
+                "w",
+            ) as outfile:
+                for line in infile:
+                    if not any([empty in line for empty in emptylist]):
+                        line = line.replace(perm_prefix, thisprefix)
+                        line = line.replace(perm_suffix, thissuffix)
+                        outfile.write(line)
+
+        IJ.run("Grid/Collection stitching", copy_grid_instructions)
+        im0 = IJ.getImage()
+        # chop off the opposite edige
+        IJ.makeRectangle(
+            quarter_options["crop_numerical_position"][0], 
+            quarter_options["crop_numerical_position"][1], 
+            im0.width + quarter_options["crop_numerical_position"][2], 
+            im0.height + quarter_options["crop_numerical_position"][3]
+        )
+        im1 = im0.crop()
+        width = str(int(round(im1.width * float(scalingstring))))
+        height = str(int(round(im1.height * float(scalingstring))))
+        print(
+            "Scale...",
+            "x="
+            + scalingstring
+            + " y="
+            + scalingstring
+            + " width="
+            + width
+            + " height="
+            + height
+            + " interpolation=Bilinear average create",
+        )
+        IJ.run(
+            "Scale...",
+            "x="
+            + scalingstring
+            + " y="
+            + scalingstring
+            + " width="
+            + width
+            + " height="
+            + height
+            + " interpolation=Bilinear average create",
+        )
+        time.sleep(15)
+        im2 = IJ.getImage()
+        print(
+            "Canvas Size...",
+            "width="
+            + str(upscaled_col_size)
+            + " height="
+            + str(upscaled_row_size)
+            + " position="+quarter_options["position"],
+        )
+        IJ.run(
+            "Canvas Size...",
+            "width="
+            + str(upscaled_col_size)
+            + " height="
+            + str(upscaled_row_size)
+            + " position="+quarter_options["position"],
+        )
+        time.sleep(15)
+        im3 = IJ.getImage()
+        savefile(
+            im3,
+            os.path.join(out_subdir, fileoutname),
+            plugin,
+            compress=compress,
+        )
+        im = IJ.getImage()
+        print(
+            "Scale...",
+            "x=0.1 y=0.1 width="
+            + str(im.width / 10)
+            + " height="
+            + str(im.width / 10)
+            + " interpolation=Bilinear average create",
+        )
+        im_10 = IJ.run(
+            "Scale...",
+            "x=0.1 y=0.1 width="
+            + str(im.width / 10)
+            + " height="
+            + str(im.width / 10)
+            + " interpolation=Bilinear average create",
+        )
+        im_10 = IJ.getImage()
+        savefile(
+            im_10,
+            os.path.join(downsample_subdir, fileoutname),
+            plugin,
+            compress=compress,
+        )
+        IJ.run("Close All")
+        im = IJ.open(os.path.abspath(os.path.join(out_subdir, fileoutname)))
+        im = IJ.getImage()
+        tiles_to_make = quarter_options["tile_coords_for_final_tiles"]
+        plate = fileoutname.split("Plate_")[1].split("_Well_")[0]
+        for eachtile in tiles_to_make.keys():
+            IJ.makeRectangle(
+                tiles_to_make[eachtile][0],
+                tiles_to_make[eachtile][1],
+                tilesize,
+                tilesize,
+            )
+            im_tile = im.crop()
+            savefile(
+                im_tile,
+                os.path.join(
+                    tile_subdir_persuf,
+                    thissuffixnicename
+                    + "_Plate_"
+                    + str(plate)
+                    + "_Well_"
+                    + str(eachwell)
+                    + "_Site_"
+                    + str(eachtile)
+                    + ".tiff",
+                ),
+                plugin,
+                compress=compress,
+            )
+        IJ.run("Close All")
+
+def get_round_rows_cols(im_per_well_dict, phenix_im_per_well_dict, imperwell, phenix):
+    if not phenix: #assume we snake back and forth, like a sane microscope
+        try:
+            row_widths = im_per_well_dict[imperwell]
+            rows = str(len(row_widths))
+            columns = str(max(row_widths))
+        except:
+            print(imperwell, "images/well for a round well is not currently supported")
+            sys.exit()
+        
+    else:
+        try: 
+            row_pattern = phenix_im_per_well_dict[imperwell]
+            row_widths = range(len(row_pattern))
+            column_widths = range(len(row_pattern[0]))
+            rows = str(len(row_widths))
+            columns = str(len(column_widths))
+        except:
+            print(imperwell, "images/well for a round Phenix well is not currently supported")
+            sys.exit()
+    return rows, columns
+        
+def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwell,size,
+                      well_list, prefix_suffix_list, subdir, phenix=False):
+    """Makes the new blank file and the renamed files, return the empty list of things that won't align"""
+    pos_dict = {}
+    emptylist = [] 
+
+    if not phenix: #assume we snake back and forth, like a sane microscope
+        row_widths = im_per_well_dict[imperwell]
+        try:
+            rows = str(len(row_widths))
+            columns = str(max(row_widths))
+            count = 0
+
+            for row in range(len(row_widths)):
+                row_width = row_widths[row]
+                left_pos = int((int(columns) - row_width) / 2)
+                for col in range(row_width):
+                    if row % 2 == 0:
+                        pos_dict[(int(left_pos + col), row)] = str(count)
+                        count += 1
+                    else:
+                        right_pos = left_pos + row_width - 1
+                        pos_dict[(int(right_pos - col), row)] = str(count)
+                        count += 1
+        except:
+            print("failed at trying to create position dict from images per well")
+            sys.exit()
+    else: #since the Phenix, due to its initial center position, isn't easy to mathematically model, we just had to hardcode the positions
+        row_pattern = phenix_im_per_well_dict[imperwell]
+
+        try:
+            row_widths = range(len(row_pattern))
+            column_widths = range(len(row_pattern[0]))
+            rows = str(len(row_widths))
+            columns = str(len(column_widths))
+            for row in row_widths:
+                for col in column_widths:
+                    siteval = row_pattern[row][col]
+                    if siteval != "":
+                        pos_dict[(col, row)] = str(siteval)
+        except:
+            print("failed at trying to create position dict from images per well") 
+            sys.exit()
+
+    filled_positions = pos_dict.keys()
+    #print(os.listdir('.'),os.listdir(subdir))
+    for eachwell in well_list:
+        for eachpresuf in prefix_suffix_list:
+            thisprefix, thissuffix = eachpresuf
+            for x in range(int(columns)):
+                for y in range(int(rows)):
+                    out_name = (
+                        thisprefix
+                        + "_Well_"
+                        + eachwell
+                        + "_x_"
+                        + "%02d" % x
+                        + "_y_"
+                        + "%02d" % y
+                        + "_"
+                        + thissuffix
+                    )
+                    if (x, y) in filled_positions:
+                        #Note- if we ever decide to not have renamed things (ie, not illum correct barcode), work is needed here
+                        series = pos_dict[(x, y)]
+                        in_name = (
+                            thisprefix
+                            + "_Well_"
+                            + eachwell
+                            + "_Site_"
+                            + str(series)
+                            + "_"
+                            + thissuffix
+                        )
+                        IJ.open(os.path.abspath(os.path.join(subdir,in_name)))
+                    else:
+                        IJ.newImage(
+                            "Untitled", "16-bit noise", int(size), int(size), 1
+                        )
+                        IJ.run(
+                            "Divide...", "value=100"
+                        )  # get the noise value below the real camera noise level
+                        emptylist.append(out_name)
+                    im = IJ.getImage()
+                    IJ.saveAs(im, "tiff", os.path.join(subdir, out_name))
+                    IJ.run("Close All")
+                    if (x, y) in filled_positions:
+                        try:  # try to clean up after yourself, but don't die if you can't
+                            os.remove(os.path.join(subdir, in_name))
+                        except:
+                            pass
+            print(
+                "Renamed all files for prefix "
+                + thisprefix
+                + " and suffix "
+                + thissuffix
+                + " in well "
+                + eachwell
+            )
+        imagelist = os.listdir(subdir)
+        print(len(imagelist), "files in subdir")
+        print("first ten images in imagelist", imagelist[:10])
+        return emptylist, rows, columns
+
+def determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, columns, 
+                                          stitched_quarter_dict, final_tile_size, yoffset_tiles=0, xoffset_tiles=0):
+    """Return final parameters for how many tiles we're going to have, and what sizes they'll be.
+    
+    For cases where we're quartering a large round well, it also does the crop determination;
+    this includes the first_file_offset indices passed to GridStitcher (so that it knows and expects
+    to stitch e.g. only columns 6-10 rather than 1-5) and human-determined offsets which alter where the
+    lines between parts of the circle are drawn (rare, implmented I THINK mostly for alignment issues if 
+    I recall correctly, which I may not). """
+
+    tileperside = int(tileperside)
+    scale_factor = float(scalingstring)
+    rounded_scale_factor = int(round(scale_factor))
+    if round_or_square == 'square':
+        stitchedsize = int(rows) * int(size)
+        upscaled_row_size = int(stitchedsize * rounded_scale_factor)
+        if upscaled_row_size > 46340:
+            upscaled_row_size = 46340
+        upscaled_col_size = upscaled_row_size
+        tilesize = int(upscaled_row_size / tileperside)
+        pixels_to_crop = None
+    else:
+        tilesize = int(final_tile_size)
+    if quarter_if_round.lower() == "true":
+        # xoffset_tiles and yoffset_tiles can be used if you need to adjust the "where to draw the line between quarters"
+        # by a whole tile. You may want to add more padding if you do this
+        top_rows = str((int(rows) / 2) + int(yoffset_tiles))
+        left_columns = str((int(columns) / 2) + int(xoffset_tiles))
+        bot_rows = str(int(rows) - int(top_rows))
+        right_columns = str(int(columns) - int(left_columns))
+        # For upscaled row and column size, we're always going to use the biggest number, we'd rather pad than miss stuff
+        # Because we can't assure same final tile size now either, now we need to specify it, ugh, and make sure the padding is big enough
+        max_val = max(
+            int(top_rows), int(bot_rows), int(left_columns), int(right_columns)
+        )
+        upscaled_row_size = int(size) * max_val * rounded_scale_factor
+        tiles_per_quarter = int(tileperside) / 2
+        if tilesize * tiles_per_quarter > upscaled_row_size:
+            upscaled_row_size = tilesize * tiles_per_quarter
+        upscaled_col_size = upscaled_row_size
+        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter) #I'm not sure how this works? 
+        pixels_to_crop = int(round(int(size) * float(overlap_pct) / 200)) #I'm not sure how this works either?
+
+        #top left
+        stitched_quarter_dict["TopLeft"]["grid_size_x"] = left_columns
+        stitched_quarter_dict["TopLeft"]["grid_size_y"] = top_rows
+        stitched_quarter_dict["TopLeft"]["crop_numerical_position"] = [0,0,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["TopLeft"]["first_file_index_offset_x"] = 0
+        stitched_quarter_dict["TopLeft"]["first_file_index_offset_y"] = 0
+        for eachxtile in range(tiles_per_quarter):
+            for eachytile in range(tiles_per_quarter):
+                each_tile_num = eachxtile*int(tileperside) + eachytile + 1
+                stitched_quarter_dict["TopLeft"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize)+tile_offset, (eachytile*tilesize)+tile_offset)
+        #top right
+        stitched_quarter_dict["TopRight"]["grid_size_x"] = right_columns
+        stitched_quarter_dict["TopRight"]["grid_size_y"] = top_rows
+        stitched_quarter_dict["TopRight"]["crop_numerical_position"] = [pixels_to_crop,0,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["TopRight"]["first_file_index_offset_x"] = left_columns
+        stitched_quarter_dict["TopRight"]["first_file_index_offset_y"] = 0
+        for eachxtile in range(tiles_per_quarter):
+            for eachytile in range(tiles_per_quarter):
+                each_tile_num = (
+                                int(tiles_per_quarter) * int(tileperside)
+                                + eachxtile * int(tileperside)
+                                + eachytile
+                                + 1
+                            )
+                stitched_quarter_dict["TopRight"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize), (eachytile*tilesize)+tile_offset)
+        #bot left
+        stitched_quarter_dict["BotLeft"]["grid_size_x"] = left_columns
+        stitched_quarter_dict["BotLeft"]["grid_size_y"] = bot_rows
+        stitched_quarter_dict["BotLeft"]["crop_numerical_position"] = [0,pixels_to_crop,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["BotLeft"]["first_file_index_offset_x"] = 0
+        stitched_quarter_dict["BotLeft"]["first_file_index_offset_y"] = top_rows 
+        for eachxtile in range(tiles_per_quarter):
+            for eachytile in range(tiles_per_quarter):
+                each_tile_num = (
+                                eachxtile * int(tileperside)
+                                + int(tiles_per_quarter)
+                                + eachytile
+                                + 1
+                            )
+                stitched_quarter_dict["BotLeft"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize)+tile_offset, (eachytile*tilesize))
+        #bot right
+        stitched_quarter_dict["BotRight"]["grid_size_x"] = right_columns
+        stitched_quarter_dict["BotRight"]["grid_size_y"] = bot_rows
+        stitched_quarter_dict["BotRight"]["crop_numerical_position"] = [pixels_to_crop,pixels_to_crop,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["BotRight"]["first_file_index_offset_x"] = left_columns
+        stitched_quarter_dict["BotRight"]["first_file_index_offset_y"] = top_rows
+        for eachxtile in range(tiles_per_quarter):
+            for eachytile in range(tiles_per_quarter):
+                each_tile_num = each_tile_num = (
+                                int(tiles_per_quarter) * int(tileperside)
+                                + eachxtile * int(tileperside)
+                                + int(tiles_per_quarter)
+                                + eachytile
+                                + 1
+                            )
+                stitched_quarter_dict["BotRight"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile * tilesize),(eachytile * tilesize))
+
+    else:
+        max_val = max(int(rows), int(columns))
+        upscaled_row_size = int(size) * max_val * rounded_scale_factor
+        if tilesize * tileperside > upscaled_row_size:
+            upscaled_row_size = tilesize * tileperside
+        upscaled_col_size = upscaled_row_size
+        pixels_to_crop = None
+    
+    return tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor
+
+# ACTUAL CODE TO RUN STARTS HERE, EVERYTHING ABOVE COULD BE A UTIL
+
 # Define and create the folders where the images will be output
 out_subdir = 'stitched_images'
 tile_subdir = 'cropped_images'
@@ -77,597 +868,71 @@ if not os.path.exists(downsample_subdir):
 
 subdir=os.path.join(input_file_location,subdir)
 
-
 if os.path.isdir(subdir):
-        dirlist=os.listdir(subdir)
-        welllist=[]
-        presuflist = []
-        permprefix = None
-        permsuffix = None
-        for eachfile in dirlist:
-                        if '.tif' in eachfile:
-                                if filterstring in eachfile:
-                                        if 'Overlay' not in eachfile:
-                                                prefixBeforeWell,suffixWithWell=eachfile.split('_Well_')
-                                                Well,suffixAfterWell=suffixWithWell.split('_Site_')
-                                                channelSuffix = suffixAfterWell[suffixAfterWell.index('_')+1:]
-                                                if (prefixBeforeWell,channelSuffix) not in presuflist:
-                                                        presuflist.append((prefixBeforeWell,channelSuffix))
-                                                if Well not in welllist:
-                                                        welllist.append(Well)
-                                                if channame in channelSuffix:
-                                                        if permprefix == None:
-                                                                permprefix=prefixBeforeWell
-                                                                permsuffix=channelSuffix
+    dir_list, well_list, prefix_suffix_list, perm_prefix, perm_suffix = parse_files(subdir, channame, filterstring)
 
-        for eachpresuf in presuflist:
-                if eachpresuf[1][-4:]!='.tif':
-                        if eachpresuf[1][-5:]!='.tiff':
-                                presuflist.remove(eachpresuf)
-        presuflist.sort()
-        print welllist, presuflist
+    # Measure actual image size from the first file
+    first_image_path = os.path.join(subdir, perm_prefix + "_Well_" + well_list[0] + "_Site_1_" + perm_suffix)
+    imp = IJ.openImage(first_image_path)
+    size = str(imp.getWidth())
+    imp.close()
 
-        # Error if no channel matched channame - requires explicit CHANNAME configuration
-        if permprefix is None:
-                print("ERROR: CHANNAME '"+channame+"' not found in any file.")
-                print("Available channels: " + str([ps[1] for ps in presuflist]))
-                print("Set CHANNAME environment variable to match one of the available channels.")
-                sys.exit(1)
+    if round_or_square == "round": # We usually infer rows and columns from the im_per_well_dict for round
+        do_phenix = phenix.lower()=="true"
+        rows, columns = get_round_rows_cols(im_per_well_dict, phenix_im_per_well_dict, imperwell, phenix = do_phenix)
+    
+    #Get final sizes for things, including all random funky offsets
+    tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor = determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, columns, 
+                                        stitched_quarter_dict, final_tile_size, yoffset_tiles=yoffset_tiles, xoffset_tiles=xoffset_tiles)
+    
+    print("finished the parsing",tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor)
+    if round_or_square == "square":
+        for eachwell in well_list:
+            run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
+                                perm_prefix, eachwell, perm_suffix, compress, out_subdir, plugin, stitched_quarter_dict, quarter = False,)
+            for eachpresuf in prefix_suffix_list:  # for each channel
+                apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
+                                stitched_quarter_dict, compress, upscaled_row_size=upscaled_row_size, upscaled_col_size=upscaled_col_size)
+    elif round_or_square == "round":
+        # do renaming and mapping of where each position is
+        # Since the Grid/Collection plugin requires squares, this also makes empty tiles 
+        # at the edges to pad the circle into a square
+        emptylist, rows, columns = map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwell,size,
+                      well_list, prefix_suffix_list, subdir, phenix=do_phenix)
+        
+        #The mapper doesn't know what the permament prefix and suffix are, so we'll subset this for speed
+        print("perm_prefix", perm_prefix)
+        print("perm_suffix", perm_suffix)
+        print("emptylist before subsetting", emptylist)
+        emptylist = [x for x in emptylist if perm_prefix in x if perm_suffix in x]
+        print("emptylist after subsetting", emptylist)
 
-        if round_or_square == 'square':
-                stitchedsize=int(rows)*int(size)
-                tileperside=int(tileperside)
-                scale_factor=float(scalingstring)
-                rounded_scale_factor=int(round(scale_factor))
-                upscaledsize=int(stitchedsize*rounded_scale_factor)
-                if upscaledsize > 46340:
-                        upscaledsize = 46340
-                tilesize=int(upscaledsize/tileperside)
+        for eachwell in well_list:
+            if quarter_if_round.lower() == "false": #The whole well should be stitched
+                run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
+                                perm_prefix, eachwell, perm_suffix, compress, 
+                                out_subdir, plugin, stitched_quarter_dict, quarter = False,)
+                # cropping
+                for eachpresuf in prefix_suffix_list:  # for each channel
+                    apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
+                                stitched_quarter_dict, compress, emptylist=emptylist, upscaled_row_size=upscaled_row_size, upscaled_col_size=upscaled_col_size)
+            else:
+                for quarter in stitched_quarter_dict.keys(): #The well is over Fiji's max size limit, so we'll stitch in quarters
+                    run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
+                                perm_prefix, eachwell, perm_suffix, compress, 
+                                out_subdir, plugin, stitched_quarter_dict, quarter = quarter)
+                    for eachpresuf in prefix_suffix_list:
+                        apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize,
+                                stitched_quarter_dict, compress, quarter = quarter, emptylist=emptylist, upscaled_row_size=upscaled_row_size, 
+                                upscaled_col_size=upscaled_col_size)
 
-                for eachwell in welllist:
-                        standard_grid_instructions=["type=["+stitchorder+"] order=[Right & Down                ] grid_size_x="+rows+" grid_size_y="+columns+" tile_overlap="+overlap_pct+" first_file_index_i="+first_site_index+" directory="+subdir+" file_names=",
-                        " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                        copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                        filename=permprefix+'_Well_'+eachwell+'_Site_{i}_'+permsuffix
-                        fileoutname='Stitched'+filename.replace("{i}","")
-                        IJ.run("Grid/Collection stitching", standard_grid_instructions[0] + filename + standard_grid_instructions[1])
-                        im=IJ.getImage()
-                        #We're going to overwrite this file later, but it gives is a chance for an early checkpoint
-                        #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                        if compress.lower()!='true':
-                                savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                        IJ.run("Close All")
-                        for eachpresuf in presuflist: # for each channel
-                                thisprefix, thissuffix=eachpresuf
-                                thissuffixnicename = thissuffix.split('.')[0]
-                                if thissuffixnicename[0]=='_':
-                                        thissuffixnicename=thissuffixnicename[1:]
-
-                                filename=thisprefix+'_Well_'+eachwell+'_Site_{i}_'+thissuffix
-                                fileoutname='Stitched'+filename.replace("{i}","")
-                                with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                for line in infile:
-                                                        line=line.replace(permprefix,thisprefix)
-                                                        line=line.replace(permsuffix,thissuffix)
-                                                        outfile.write(line)
-
-                                IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                im=IJ.getImage()
-                                width = str(int(round(im.width*float(scalingstring))))
-                                height = str(int(round(im.height*float(scalingstring))))
-                                # scale the barcoding and cell painting images to match each other
-                                print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                time.sleep(15)
-                                im2=IJ.getImage()
-                                #padding to ensure tiles are all the same size (for CellProfiler later on)
-                                print("Canvas Size...", "width="+str(upscaledsize)+" height="+str(upscaledsize)+" position=Top-Left zero")
-                                IJ.run("Canvas Size...", "width="+str(upscaledsize)+" height="+str(upscaledsize)+" position=Top-Left zero")
-                                time.sleep(15)
-                                im3=IJ.getImage()
-                                savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                im=IJ.getImage()
-                                #scaling to make a downsampled image for QC
-                                print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                im_10=IJ.getImage()
-                                savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                IJ.run("Close All")
-                                im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                im = IJ.getImage()
-                                for eachxtile in range(tileperside):
-                                        for eachytile in range(tileperside):
-                                                each_tile_num = eachxtile*tileperside + eachytile + 1
-                                                IJ.makeRectangle(eachxtile*tilesize, eachytile*tilesize,tilesize,tilesize)
-                                                im_tile=im.crop()
-                                                savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                IJ.run("Close All")
-        elif round_or_square == 'round':
-                if imperwell == '1364':
-                        row_widths = [8,14,18,22,26,28,30,
-                        32,34,34,36,36,38,38,
-                        40,40,40,42,42,42,42,
-                        42,42,42,42,40,40,40,
-                        38,38,36,36,34,34,32,
-                        30,28,26,22,18,14,8]
-                elif imperwell == '1332':
-                        row_widths = [14,18,22,26,28,30,
-                        32,34,34,36,36,38,38,
-                        40,40,40,40,40,40,40,
-                        40,40,40,40,40,40,40,
-                        38,38,36,36,34,34,32,
-                        30,28,26,22,18,14]
-                elif imperwell == '1396':
-                        row_widths = [18,22,26,28,30,
-                        32,34,36,36,38,38,
-                        40,40,40,40,40,40,40,40,40,
-                        40,40,40,40,40,40,40,40,40,
-                        38,38,36,36,34,32,
-                        30,28,26,22,18]
-                elif imperwell == '1025':
-                        row_widths = [5,11,17,19,23,25,27,29,29,31,33,33,33,35,35,35,37,37,37,37,37,35,35,35,33,33,33,31,29,29,27,25,23,19,17,11,5]
-                elif imperwell == '394':
-                        row_widths = [3,7,9,11,11,
-                        13,13,15,15,15,
-                        17,17,17,17,17,17,17,17,17,17,
-                        15,15,15,13,13,11,11,9,7,3]
-                elif imperwell == '320':
-                        row_widths = [4, 8, 12, 14, 16,
-                        18, 18, 20, 20, 20,
-                        20, 20, 20, 20, 18,
-                        18, 16, 14, 12, 8, 4]
-                elif imperwell == '316':
-                        row_widths = [6, 10, 14, 16, 16,
-                        18, 18, 20, 20, 20,
-                        20, 20, 20, 18, 18,
-                        16, 16, 14, 10, 6]
-                elif imperwell == '293':
-                        row_widths = [7, 11, 13, 15, 17, 17,
-                        19, 19, 19, 19, 19, 19, 19, 17, 17,
-                        15, 13, 11, 7]
-                elif imperwell == '88':
-                        row_widths = [6, 8, 10, 10, 10, 10, 10, 10, 8, 6]
-                elif imperwell == '256':
-                        row_widths = [6,10,12,14,16,16,18,18,18,18,18,18,16,16,14,12,10,6]
-                elif imperwell == '52':
-                        row_widths = [4,6,8,8,8,8,6,4]
-                elif imperwell == '56':
-                        row_widths = [2, 6, 8, 8, 8, 8, 8, 6, 2]
-                elif imperwell == '45':
-                        row_widths = [5,7,7,7,7,7,5]
-                else:
-                        print(imperwell, "images/well for a round well is not currently supported")
-                        sys.exit()
-
-                rows = str(len(row_widths))
-                columns = str(max(row_widths))
-
-                tileperside = int(tileperside)
-                tilesize=int(final_tile_size)
-                scale_factor=float(scalingstring)
-                rounded_scale_factor=int(round(scale_factor))
-
-                if quarter_if_round.lower() == "true":
-                        # xoffset_tiles and yoffset_tiles can be used if you need to adjust the "where to draw the line between quarters"
-                        # by a whole tile. You may want to add more padding if you do this
-                        top_rows = str((int(rows)/2)+int(yoffset_tiles))
-                        left_columns = str((int(columns)/2)+int(xoffset_tiles))
-                        bot_rows = str(int(rows)-int(top_rows))
-                        right_columns = str(int(columns)-int(left_columns))
-                        #For upscaled row and column size, we're always going to use the biggest number, we'd rather pad than miss stuff
-                        #Because we can't assure same final tile size now either, now we need to specify it, ugh, and make sure the padding is big enough
-                        max_val = max(int(top_rows),int(bot_rows),int(left_columns),int(right_columns))
-                        upscaled_row_size=int(size)*max_val*rounded_scale_factor
-                        tiles_per_quarter = int(tileperside)/2
-                        if tilesize * tiles_per_quarter > upscaled_row_size:
-                                upscaled_row_size = tilesize * tiles_per_quarter
-                        upscaled_col_size=upscaled_row_size
-                        pixels_to_crop = int(round(int(size)*float(overlap_pct)/200))
-                else:
-                        max_val = max(int(rows), int(columns))
-                        upscaled_row_size=int(size)*max_val*rounded_scale_factor
-                        if tilesize * tileperside > upscaled_row_size:
-                                upscaled_row_size = tilesize * tileperside
-                        upscaled_col_size=upscaled_row_size
-
-                pos_dict = {}
-                count = 0
-                for row in range(len(row_widths)):
-                        row_width = row_widths[row]
-                        left_pos = int((int(columns)-row_width)/2)
-                        for col in range(row_width):
-                                if row%2 == 0:
-                                        pos_dict[(int(left_pos + col), row)] = str(count)
-                                        count += 1
-                                else:
-                                        right_pos = left_pos + row_width - 1
-                                        pos_dict[(int(right_pos - col), row)]= str(count)
-                                        count += 1
-
-                filled_positions = pos_dict.keys()
-                emptylist = []
-                for eachwell in welllist:
-                        for eachpresuf in presuflist:
-                                thisprefix, thissuffix=eachpresuf
-                                for x in range(int(columns)):
-                                        for y in range(int(rows)):
-                                                out_name = thisprefix+'_Well_'+eachwell+'_x_'+ '%02d'%x+'_y_'+'%02d'%y+ '_'+ thissuffix
-                                                if (x,y) in filled_positions:
-                                                        series = pos_dict[(x,y)]
-                                                        in_name = thisprefix+'_Well_'+eachwell+'_Site_'+str(series)+'_'+thissuffix
-                                                        IJ.open(os.path.join(subdir,in_name))
-                                                else:
-                                                        IJ.newImage("Untitled", "16-bit noise",int(size),int(size), 1)
-                                                        IJ.run("Divide...", "value=100") #get the noise value below the real camera noise level
-                                                        emptylist.append(out_name)
-                                                im = IJ.getImage()
-                                                IJ.saveAs(im,'tiff',os.path.join(subdir, out_name))
-                                                IJ.run("Close All")
-                                                if (x,y) in filled_positions:
-                                                        try: #try to clean up after yourself, but don't die if you can't
-                                                                os.remove(os.path.join(subdir,in_name))
-                                                        except:
-                                                                pass
-                                print("Renamed all files for prefix "+thisprefix+" and suffix "+thissuffix+" in well "+eachwell)
-                        imagelist = os.listdir(subdir)
-                        print(len(imagelist), 'files in subdir')
-                        print(imagelist[:10])
-
-                        if quarter_if_round.lower() == "false":
-                                #all quarters
-                                print('Stitching whole well')
-                                standard_grid_instructions=["type=[Filename defined position] order=[Defined by filename         ] grid_size_x="+str(columns)+" grid_size_y="+str(rows)+" tile_overlap="+overlap_pct+" first_file_index_x=0 first_file_index_y=0 directory="+subdir+" file_names=",
-                                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                                copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                                filename=permprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+permsuffix
-                                fileoutname='Stitched'+filename.replace("{i}","")
-                                instructions = standard_grid_instructions[0] + filename + standard_grid_instructions[1]
-                                print(instructions)
-                                IJ.run("Grid/Collection stitching", instructions)
-                                im=IJ.getImage()
-                                #We're going to overwrite this file later, but it gives us a chance for an early checkpoint
-                                #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                                if compress.lower()!='true':
-                                        savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                print(os.path.join(out_subdir,fileoutname))
-                                time.sleep(300)
-                                IJ.run("Close All")
-                                # cropping
-                                for eachpresuf in presuflist: # for each channel
-                                        thisprefix, thissuffix=eachpresuf
-                                        thissuffixnicename = thissuffix.split('.')[0]
-                                        if thissuffixnicename[0]=='_':
-                                                thissuffixnicename=thissuffixnicename[1:]
-
-                                        filename=thisprefix+'_Well_'+eachwell+'_Site_{i}_'+thissuffix
-                                        fileoutname='Stitched'+filename.replace("{i}","")
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                                with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                        for line in infile:
-                                                                line=line.replace(permprefix,thisprefix)
-                                                                line=line.replace(permsuffix,thissuffix)
-                                                                outfile.write(line)
-
-                                        IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                        im=IJ.getImage()
-                                        width = str(int(round(im.width*float(scalingstring))))
-                                        height = str(int(round(im.height*float(scalingstring))))
-                                        # scale the barcoding and cell painting images to match each other
-                                        print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        time.sleep(15)
-                                        im2=IJ.getImage()
-                                        #padding to ensure tiles are all the same size (for CellProfiler later on)
-                                        print("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Left zero")
-                                        IJ.run("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Left zero")
-                                        time.sleep(15)
-                                        im3=IJ.getImage()
-                                        savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                        im=IJ.getImage()
-                                        #scaling to make a downsampled image for QC
-                                        print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.getImage()
-                                        savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                        IJ.run("Close All")
-                                        im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                        im = IJ.getImage()
-                                        for eachxtile in range(tileperside):
-                                                for eachytile in range(tileperside):
-                                                        each_tile_num = eachxtile*tileperside + eachytile + 1
-                                                        IJ.makeRectangle(eachxtile*tilesize, eachytile*tilesize,tilesize,tilesize)
-                                                        im_tile=im.crop()
-                                                        savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                        IJ.run("Close All")
-
-
-                        else:
-                                #top left quarter
-                                print('Running top left')
-                                #Change per quarter
-                                standard_grid_instructions=["type=[Filename defined position] order=[Defined by filename         ] grid_size_x="+str(left_columns)+" grid_size_y="+top_rows+" tile_overlap="+overlap_pct+" first_file_index_x=0 first_file_index_y=0 directory="+subdir+" file_names=",
-                                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                                copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                                filename=permprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+permsuffix
-                                #Change per quarter
-                                fileoutname='StitchedTopLeft'+filename.replace("{xx}","").replace("{yy}","")
-                                instructions = standard_grid_instructions[0] + filename + standard_grid_instructions[1]
-                                print(instructions)
-                                IJ.run("Grid/Collection stitching", instructions)
-                                im=IJ.getImage()
-                                #We're going to overwrite this file later, but it gives us a chance for an early checkpoint
-                                #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                                if compress.lower()!='true':
-                                        savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                IJ.run("Close All")
-                                for eachpresuf in presuflist:
-                                        thisprefix, thissuffix=eachpresuf
-                                        thissuffixnicename = thissuffix.split('.')[0]
-                                        if thissuffixnicename[0]=='_':
-                                                thissuffixnicename=thissuffixnicename[1:]
-
-                                        filename=thisprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+thissuffix
-                                        #Change per quarter
-                                        fileoutname='StitchedTopLeft'+filename.replace("{xx}","").replace("{yy}","")
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                                with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                        for line in infile:
-                                                                if not any([empty in line for empty in emptylist]):
-                                                                        line=line.replace(permprefix,thisprefix)
-                                                                        line=line.replace(permsuffix,thissuffix)
-                                                                        outfile.write(line)
-
-                                        IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                        im0=IJ.getImage()
-                                        #chop off the bottom and right
-                                        #Change per quarter
-                                        IJ.makeRectangle(0,0,im0.width-pixels_to_crop,im0.height-pixels_to_crop)
-                                        im1=im0.crop()
-                                        width = str(int(round(im1.width*float(scalingstring))))
-                                        height = str(int(round(im1.height*float(scalingstring))))
-                                        print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        time.sleep(15)
-                                        im2=IJ.getImage()
-                                        #Chnage per quarter
-                                        print("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Bottom-Right zero")
-                                        IJ.run("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Bottom-Right zero")
-                                        time.sleep(15)
-                                        im3=IJ.getImage()
-                                        savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                        im=IJ.getImage()
-                                        print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.getImage()
-                                        savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                        IJ.run("Close All")
-                                        im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                        im = IJ.getImage()
-                                        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter)
-                                        for eachxtile in range(tiles_per_quarter):
-                                                for eachytile in range(tiles_per_quarter):
-                                                        #Change per quarter
-                                                        each_tile_num = eachxtile*int(tileperside) + eachytile + 1
-                                                        #Change per quarter
-                                                        IJ.makeRectangle((eachxtile*tilesize)+tile_offset, (eachytile*tilesize)+tile_offset,tilesize,tilesize)
-                                                        im_tile=im.crop()
-                                                        savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                        IJ.run("Close All")
-
-                                #top right quarter
-                                print('Running top right')
-                                #Change per quarter
-                                standard_grid_instructions=["type=[Filename defined position] order=[Defined by filename         ] grid_size_x="+str(right_columns)+" grid_size_y="+top_rows+" tile_overlap="+overlap_pct+" first_file_index_x="+str(left_columns)+" first_file_index_y=0 directory="+subdir+" file_names=",
-                                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                                copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                                filename=permprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+permsuffix
-                                #Change per quarter
-                                fileoutname='StitchedTopRight'+filename.replace("{xx}","").replace("{yy}","")
-                                IJ.run("Grid/Collection stitching", standard_grid_instructions[0] + filename + standard_grid_instructions[1])
-                                im=IJ.getImage()
-                                #We're going to overwrite this file later, but it gives us a chance for an early checkpoint
-                                #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                                if compress.lower()!='true':
-                                        savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                IJ.run("Close All")
-                                for eachpresuf in presuflist:
-                                        thisprefix, thissuffix=eachpresuf
-                                        thissuffixnicename = thissuffix.split('.')[0]
-                                        if thissuffixnicename[0]=='_':
-                                                thissuffixnicename=thissuffixnicename[1:]
-
-                                        filename=thisprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+thissuffix
-                                        #Change per quarter
-                                        fileoutname='StitchedTopRight'+filename.replace("{xx}","").replace("{yy}","")
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                                with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                        for line in infile:
-                                                                if not any([empty in line for empty in emptylist]):
-                                                                        line=line.replace(permprefix,thisprefix)
-                                                                        line=line.replace(permsuffix,thissuffix)
-                                                                        outfile.write(line)
-
-                                        IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                        im0=IJ.getImage()
-                                        #chop off the bottom and left
-                                        #Change per quarter
-                                        IJ.makeRectangle(pixels_to_crop,0,im0.width-pixels_to_crop,im0.height-pixels_to_crop)
-                                        im1=im0.crop()
-                                        width = str(int(round(im1.width*float(scalingstring))))
-                                        height = str(int(round(im1.height*float(scalingstring))))
-                                        print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        time.sleep(15)
-                                        im2=IJ.getImage()
-                                        #Chnage per quarter
-                                        print("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Bottom-Left zero")
-                                        IJ.run("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Bottom-Left zero")
-                                        time.sleep(15)
-                                        im3=IJ.getImage()
-                                        savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                        im=IJ.getImage()
-                                        print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.getImage()
-                                        savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                        IJ.run("Close All")
-                                        im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                        im = IJ.getImage()
-                                        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter)
-                                        for eachxtile in range(tiles_per_quarter):
-                                                for eachytile in range(tiles_per_quarter):
-                                                        #Change per quarter
-                                                        each_tile_num = int(tiles_per_quarter)*int(tileperside)+ eachxtile*int(tileperside) + eachytile + 1
-                                                        #Change per quarter
-                                                        IJ.makeRectangle((eachxtile*tilesize), (eachytile*tilesize)+tile_offset,tilesize,tilesize)
-                                                        im_tile=im.crop()
-                                                        savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                        IJ.run("Close All")
-
-                                #bottom left quarter
-                                print('Running bottom left')
-                                #Change per quarter
-                                standard_grid_instructions=["type=[Filename defined position] order=[Defined by filename         ] grid_size_x="+str(left_columns)+" grid_size_y="+bot_rows+" tile_overlap="+overlap_pct+" first_file_index_x=0 first_file_index_y="+top_rows+" directory="+subdir+" file_names=",
-                                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                                copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                                filename=permprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+permsuffix
-                                #Change per quarter
-                                fileoutname='StitchedBottomLeft'+filename.replace("{xx}","").replace("{yy}","")
-                                IJ.run("Grid/Collection stitching", standard_grid_instructions[0] + filename + standard_grid_instructions[1])
-                                im=IJ.getImage()
-                                #We're going to overwrite this file later, but it gives us a chance for an early checkpoint
-                                #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                                if compress.lower()!='true':
-                                        savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                IJ.run("Close All")
-                                for eachpresuf in presuflist:
-                                        thisprefix, thissuffix=eachpresuf
-                                        thissuffixnicename = thissuffix.split('.')[0]
-                                        if thissuffixnicename[0]=='_':
-                                                thissuffixnicename=thissuffixnicename[1:]
-
-                                        filename=thisprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+thissuffix
-                                        #Change per quarter
-                                        fileoutname='StitchedBottomLeft'+filename.replace("{xx}","").replace("{yy}","")
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                                with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                        for line in infile:
-                                                                if not any([empty in line for empty in emptylist]):
-                                                                        line=line.replace(permprefix,thisprefix)
-                                                                        line=line.replace(permsuffix,thissuffix)
-                                                                        outfile.write(line)
-
-                                        IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                        im0=IJ.getImage()
-                                        #chop off the top and right
-                                        #Change per quarter
-                                        IJ.makeRectangle(0,pixels_to_crop,im0.width-pixels_to_crop,im0.height-pixels_to_crop)
-                                        im1=im0.crop()
-                                        width = str(int(round(im1.width*float(scalingstring))))
-                                        height = str(int(round(im1.height*float(scalingstring))))
-                                        print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        time.sleep(15)
-                                        im2=IJ.getImage()
-                                        #Chnage per quarter
-                                        print("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Right zero")
-                                        IJ.run("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Right zero")
-                                        time.sleep(15)
-                                        im3=IJ.getImage()
-                                        savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                        im=IJ.getImage()
-                                        print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.getImage()
-                                        savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                        IJ.run("Close All")
-                                        im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                        im = IJ.getImage()
-                                        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter)
-                                        for eachxtile in range(tiles_per_quarter):
-                                                for eachytile in range(tiles_per_quarter):
-                                                        #Change per quarter
-                                                        each_tile_num = eachxtile*int(tileperside) + int(tiles_per_quarter) + eachytile + 1
-                                                        #Change per quarter
-                                                        IJ.makeRectangle((eachxtile*tilesize)+tile_offset, (eachytile*tilesize),tilesize,tilesize)
-                                                        im_tile=im.crop()
-                                                        savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                        IJ.run("Close All")
-
-                                #bottom right quarter
-                                print('Running bottom right')
-                                #Change per quarter
-                                standard_grid_instructions=["type=[Filename defined position] order=[Defined by filename         ] grid_size_x="+str(right_columns)+" grid_size_y="+bot_rows+" tile_overlap="+overlap_pct+" first_file_index_x="+str(left_columns)+" first_file_index_y="+top_rows+" directory="+subdir+" file_names=",
-                                " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"]
-                                copy_grid_instructions="type=[Positions from file] order=[Defined by TileConfiguration] directory="+subdir+" layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-                                filename=permprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+permsuffix
-                                #Change per quarter
-                                fileoutname='StitchedBottomRight'+filename.replace("{xx}","").replace("{yy}","")
-                                IJ.run("Grid/Collection stitching", standard_grid_instructions[0] + filename + standard_grid_instructions[1])
-                                im=IJ.getImage()
-                                #We're going to overwrite this file later, but it gives us a chance for an early checkpoint
-                                #This doesn't seem to play nicely with the compression option on, it doesn't get overwritten later and bad things happen
-                                if compress.lower()!='true':
-                                        savefile(im,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                IJ.run("Close All")
-                                for eachpresuf in presuflist:
-                                        thisprefix, thissuffix=eachpresuf
-                                        thissuffixnicename = thissuffix.split('.')[0]
-                                        if thissuffixnicename[0]=='_':
-                                                thissuffixnicename=thissuffixnicename[1:]
-
-                                        filename=thisprefix+'_Well_'+eachwell+'_x_{xx}_y_{yy}_'+thissuffix
-                                        #Change per quarter
-                                        fileoutname='StitchedBottomRight'+filename.replace("{xx}","").replace("{yy}","")
-                                        with open(os.path.join(subdir, 'TileConfiguration.registered.txt'),'r') as infile:
-                                                with open(os.path.join(subdir, 'TileConfiguration.registered_copy.txt'),'w') as outfile:
-                                                        for line in infile:
-                                                                if not any([empty in line for empty in emptylist]):
-                                                                        line=line.replace(permprefix,thisprefix)
-                                                                        line=line.replace(permsuffix,thissuffix)
-                                                                        outfile.write(line)
-
-                                        IJ.run("Grid/Collection stitching", copy_grid_instructions)
-                                        im0=IJ.getImage()
-                                        #chop off the top and left
-                                        #Change per quarter
-                                        IJ.makeRectangle(pixels_to_crop,pixels_to_crop,im0.width-pixels_to_crop,im0.height-pixels_to_crop)
-                                        im1=im0.crop()
-                                        width = str(int(round(im1.width*float(scalingstring))))
-                                        height = str(int(round(im1.height*float(scalingstring))))
-                                        print("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        IJ.run("Scale...", "x="+scalingstring+" y="+scalingstring+" width="+width+" height="+height+" interpolation=Bilinear average create")
-                                        time.sleep(15)
-                                        im2=IJ.getImage()
-                                        #Chnage per quarter
-                                        print("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Left zero")
-                                        IJ.run("Canvas Size...", "width="+str(upscaled_col_size)+" height="+str(upscaled_row_size)+" position=Top-Left zero")
-                                        time.sleep(15)
-                                        im3=IJ.getImage()
-                                        savefile(im3,os.path.join(out_subdir,fileoutname),plugin,compress=compress)
-                                        im=IJ.getImage()
-                                        print("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.run("Scale...", "x=0.1 y=0.1 width="+str(im.width/10)+" height="+str(im.width/10)+" interpolation=Bilinear average create")
-                                        im_10=IJ.getImage()
-                                        savefile(im_10,os.path.join(downsample_subdir,fileoutname),plugin,compress=compress)
-                                        IJ.run("Close All")
-                                        im=IJ.open(os.path.join(out_subdir,fileoutname))
-                                        im = IJ.getImage()
-                                        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter)
-                                        for eachxtile in range(tiles_per_quarter):
-                                                for eachytile in range(tiles_per_quarter):
-                                                        #Change per quarter
-                                                        each_tile_num = int(tiles_per_quarter)*int(tileperside) +eachxtile*int(tileperside)+ int(tiles_per_quarter) + eachytile + 1
-                                                        #Change per quarter
-                                                        IJ.makeRectangle((eachxtile*tilesize), (eachytile*tilesize),tilesize,tilesize)
-                                                        im_tile=im.crop()
-                                                        savefile(im_tile,os.path.join(tile_subdir,permprefix+'_Well_'+eachwell+'_Site_'+str(each_tile_num)+'_'+thissuffixnicename+'.tiff'),plugin,compress=compress)
-                                        IJ.run("Close All")
-
-        else:
-                print("Must identify well as round or square")
+    else:
+        print("Must identify well as round or square")
 else:
-        print("Could not find input directory ",subdir)
-for eachlogfile in ['TileConfiguration.txt','TileConfiguration.registered.txt','TileConfiguration.registered_copy.txt']:
-        os.rename(os.path.join(subdir,eachlogfile),os.path.join(out_subdir,eachlogfile))
+    print("Could not find input directory ", subdir)
+for eachlogfile in [
+    "TileConfiguration.txt",
+    "TileConfiguration.registered.txt",
+    "TileConfiguration.registered_copy.txt",
+]:
+    os.rename(os.path.join(subdir, eachlogfile), os.path.join(out_subdir, eachlogfile))

--- a/assets/stitchcrop/stitch_crop.env_master.py
+++ b/assets/stitchcrop/stitch_crop.env_master.py
@@ -25,6 +25,7 @@ xoffset_tiles = os.getenv("XOFFSET_TILES", "0")
 yoffset_tiles = os.getenv("YOFFSET_TILES", "0")
 compress = os.getenv("COMPRESS", "True")
 phenix = os.getenv("PHENIX", "False")
+save_cropped_to_subdirs = False
 
 from ij import IJ, WindowManager
 import os
@@ -588,9 +589,10 @@ def apply_stitching_per_well_section_and_channel(
         thissuffixnicename = thissuffix.split(".")[0]
         if thissuffixnicename[0] == "_":
             thissuffixnicename = thissuffixnicename[1:]
-        tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
-        if not os.path.exists(tile_subdir_persuf):
-            os.mkdir(tile_subdir_persuf)
+        if save_cropped_to_subdirs:
+            tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
+            if not os.path.exists(tile_subdir_persuf):
+                os.mkdir(tile_subdir_persuf)
         filename = thisprefix + "_Well_" + eachwell + "_Site_{i}_" + thissuffix
         fileoutname = "Stitched" + filename.replace("{i}", "")
         with open(
@@ -706,23 +708,42 @@ def apply_stitching_per_well_section_and_channel(
                     tilesize,
                 )
                 im_tile = im.crop()
-                savefile(
-                    im_tile,
-                    os.path.join(
-                        tile_subdir_persuf,
-                        "Plate_"
-                        + str(plate)
-                        + "_Well_"
-                        + str(eachwell)
-                        + "_Site_"
-                        + str(each_tile_num)
-                        + "_"
-                        + thissuffixnicename
-                        + ".tiff",
-                    ),
-                    plugin,
-                    compress=compress,
-                )
+                if save_cropped_to_subdirs:
+                    savefile(
+                        im_tile,
+                        os.path.join(
+                            tile_subdir_persuf,
+                            "Plate_"
+                            + str(plate)
+                            + "_Well_"
+                            + str(eachwell)
+                            + "_Site_"
+                            + str(each_tile_num)
+                            + "_"
+                            + thissuffixnicename
+                            + ".tiff",
+                        ),
+                        plugin,
+                        compress=compress,
+                    )
+                else:
+                    savefile(
+                        im_tile,
+                        os.path.join(
+                            tile_subdir,
+                            "Plate_"
+                            + str(plate)
+                            + "_Well_"
+                            + str(eachwell)
+                            + "_Site_"
+                            + str(each_tile_num)
+                            + "_"
+                            + thissuffixnicename
+                            + ".tiff",
+                        ),
+                        plugin,
+                        compress=compress,
+                    )
         IJ.run("Close All")
     else:
         quarter_options = stitched_quarter_dict[quarter]
@@ -730,9 +751,10 @@ def apply_stitching_per_well_section_and_channel(
         thissuffixnicename = thissuffix.split(".")[0]
         if thissuffixnicename[0] == "_":
             thissuffixnicename = thissuffixnicename[1:]
-        tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
-        if not os.path.exists(tile_subdir_persuf):
-            os.mkdir(tile_subdir_persuf)
+        if save_cropped_to_subdirs:
+            tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
+            if not os.path.exists(tile_subdir_persuf):
+                os.mkdir(tile_subdir_persuf)
         filename = thisprefix + "_Well_" + eachwell + "_x_{xx}_y_{yy}_" + thissuffix
         fileoutname = quarter_options["name"] + filename.replace("{xx}", "").replace(
             "{yy}", ""
@@ -851,23 +873,42 @@ def apply_stitching_per_well_section_and_channel(
                 tilesize,
             )
             im_tile = im.crop()
-            savefile(
-                im_tile,
-                os.path.join(
-                    tile_subdir_persuf,
-                    "Plate_"
-                    + str(plate)
-                    + "_Well_"
-                    + str(eachwell)
-                    + "_Site_"
-                    + str(eachtile)
-                    + "_"
-                    + thissuffixnicename
-                    + ".tiff",
-                ),
-                plugin,
-                compress=compress,
-            )
+            if save_cropped_to_subdirs:
+                savefile(
+                    im_tile,
+                    os.path.join(
+                        tile_subdir_persuf,
+                        "Plate_"
+                        + str(plate)
+                        + "_Well_"
+                        + str(eachwell)
+                        + "_Site_"
+                        + str(eachtile)
+                        + "_"
+                        + thissuffixnicename
+                        + ".tiff",
+                    ),
+                    plugin,
+                    compress=compress,
+                )
+            else:
+                savefile(
+                    im_tile,
+                    os.path.join(
+                        tile_subdir,
+                        "Plate_"
+                        + str(plate)
+                        + "_Well_"
+                        + str(eachwell)
+                        + "_Site_"
+                        + str(eachtile)
+                        + "_"
+                        + thissuffixnicename
+                        + ".tiff",
+                    ),
+                    plugin,
+                    compress=compress,
+                )
         IJ.run("Close All")
 
 

--- a/assets/stitchcrop/stitch_crop.env_master.py
+++ b/assets/stitchcrop/stitch_crop.env_master.py
@@ -452,13 +452,14 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
                     im_tile,
                     os.path.join(
                         tile_subdir_persuf,
-                        thissuffixnicename
-                        + "_Plate_"
+                        "Plate_"
                         + str(plate)
                         + "_Well_"
                         + str(eachwell)
                         + "_Site_"
                         + str(each_tile_num)
+                        + "_"
+                        + thissuffixnicename
                         + ".tiff",
                     ),
                     plugin,
@@ -602,13 +603,14 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
                 im_tile,
                 os.path.join(
                     tile_subdir_persuf,
-                    thissuffixnicename
-                    + "_Plate_"
+                    "Plate_"
                     + str(plate)
                     + "_Well_"
                     + str(eachwell)
                     + "_Site_"
                     + str(eachtile)
+                    + "_"
+                    + thissuffixnicename
                     + ".tiff",
                 ),
                 plugin,

--- a/assets/stitchcrop/stitch_crop.env_master.py
+++ b/assets/stitchcrop/stitch_crop.env_master.py
@@ -24,7 +24,7 @@ final_tile_size = os.getenv("FINAL_TILE_SIZE", "2960")
 xoffset_tiles = os.getenv("XOFFSET_TILES", "0")
 yoffset_tiles = os.getenv("YOFFSET_TILES", "0")
 compress = os.getenv("COMPRESS", "True")
-phenix = os.getenv("PHENIX","False")
+phenix = os.getenv("PHENIX", "False")
 
 from ij import IJ, WindowManager
 import os
@@ -34,116 +34,344 @@ import time
 
 from loci.plugins.out import Exporter
 from loci.plugins import LociExporter
+
 plugin = LociExporter()
 
-#Dict of well sizes we understand for well-patterns that start in the top left and snake towards the right and bottom
+# Dict of well sizes we understand for well-patterns that start in the top left and snake towards the right and bottom
 im_per_well_dict = {
     "1396": [
-        18, 22, 26, 28, 30, 32, 34, 36, 36, 38, 38, 40, 40, 40, 40, 40, 40, 40, 40, 40, 
-        40, 40, 40, 40, 40, 40, 40, 40, 40, 38, 38, 36, 36, 34, 32, 30, 28, 26, 22, 18,
+        18,
+        22,
+        26,
+        28,
+        30,
+        32,
+        34,
+        36,
+        36,
+        38,
+        38,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        38,
+        38,
+        36,
+        36,
+        34,
+        32,
+        30,
+        28,
+        26,
+        22,
+        18,
     ],
-    "1364": [8, 14, 18, 22, 26, 28, 30, 32, 34, 34, 36, 36, 38, 38, 40, 40, 40, 42, 42,
-        42, 42, 42, 42, 42, 42, 40, 40, 40, 38, 38, 36, 36, 34, 34, 32, 30, 28, 26, 22, 
-        18, 14, 8,
+    "1364": [
+        8,
+        14,
+        18,
+        22,
+        26,
+        28,
+        30,
+        32,
+        34,
+        34,
+        36,
+        36,
+        38,
+        38,
+        40,
+        40,
+        40,
+        42,
+        42,
+        42,
+        42,
+        42,
+        42,
+        42,
+        42,
+        40,
+        40,
+        40,
+        38,
+        38,
+        36,
+        36,
+        34,
+        34,
+        32,
+        30,
+        28,
+        26,
+        22,
+        18,
+        14,
+        8,
     ],
     "1332": [
-        14, 18, 22, 26, 28, 30, 32, 34, 34, 36, 36, 38, 38, 40, 40, 40, 40, 40, 40, 40,
-        40, 40, 40, 40, 40, 40, 40, 38, 38, 36, 36, 34, 34, 32, 30, 28, 26, 22, 18, 14,
+        14,
+        18,
+        22,
+        26,
+        28,
+        30,
+        32,
+        34,
+        34,
+        36,
+        36,
+        38,
+        38,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        40,
+        38,
+        38,
+        36,
+        36,
+        34,
+        34,
+        32,
+        30,
+        28,
+        26,
+        22,
+        18,
+        14,
     ],
-    "1025":[
-        5,11,17,19,23,25,27,29,29,31,33,33,33,35,35,35,37,37,37,37,37,35,35,35,33,
-        33,33,31,29,29,27,25,23,19,17,11,5,
+    "1025": [
+        5,
+        11,
+        17,
+        19,
+        23,
+        25,
+        27,
+        29,
+        29,
+        31,
+        33,
+        33,
+        33,
+        35,
+        35,
+        35,
+        37,
+        37,
+        37,
+        37,
+        37,
+        35,
+        35,
+        35,
+        33,
+        33,
+        33,
+        31,
+        29,
+        29,
+        27,
+        25,
+        23,
+        19,
+        17,
+        11,
+        5,
     ],
     "394": [
-        3, 7, 9, 11, 11, 13, 13, 15, 15, 15, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
-        15, 15, 15, 13, 13, 11, 11, 9, 7, 3,
+        3,
+        7,
+        9,
+        11,
+        11,
+        13,
+        13,
+        15,
+        15,
+        15,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        15,
+        15,
+        15,
+        13,
+        13,
+        11,
+        11,
+        9,
+        7,
+        3,
     ],
     "320": [
-        4, 8, 12, 14, 16, 18, 18, 20, 20, 20, 20, 20, 20, 20, 18, 18, 16, 14, 12, 8, 
+        4,
+        8,
+        12,
+        14,
+        16,
+        18,
+        18,
+        20,
+        20,
+        20,
+        20,
+        20,
+        20,
+        20,
+        18,
+        18,
+        16,
+        14,
+        12,
+        8,
         4,
     ],
-    "316": [6, 10, 14, 16, 16, 18, 18, 20, 20, 20, 20, 20, 20, 18, 18, 16, 16, 14, 10, 6],
+    "316": [
+        6,
+        10,
+        14,
+        16,
+        16,
+        18,
+        18,
+        20,
+        20,
+        20,
+        20,
+        20,
+        20,
+        18,
+        18,
+        16,
+        16,
+        14,
+        10,
+        6,
+    ],
     "293": [7, 11, 13, 15, 17, 17, 19, 19, 19, 19, 19, 19, 19, 17, 17, 15, 13, 11, 7],
     "256": [6, 10, 12, 14, 16, 16, 18, 18, 18, 18, 18, 18, 16, 16, 14, 12, 10, 6],
     "88": [6, 8, 10, 10, 10, 10, 10, 10, 8, 6],
     "56": [2, 6, 8, 8, 8, 8, 8, 6, 2],
     "52": [4, 6, 8, 8, 8, 8, 6, 4],
-    "45": [5,7,7,7,7,7,5],
+    "45": [5, 7, 7, 7, 7, 7, 5],
 }
 
-#Dict of well sizes we understand for well-patterns that start in the center, then jump to the top left and snake 
-#towards the right and bottom. As far as we know, this is just the Phenix (and friends like the Operetta)
+# Dict of well sizes we understand for well-patterns that start in the center, then jump to the top left and snake
+# towards the right and bottom. As far as we know, this is just the Phenix (and friends like the Operetta)
 phenix_im_per_well_dict = {
-    "80": [['']*3+list(range(2,6))+['']*3,
-            ['']+list(range(13,5,-1))+[''],
-            ['']+list(range(14,22))+[''],
-            list(range(31,21,-1)),
-            list(range(32,42)),
-            list(range(50,46,-1))+[1]+list(range(46,41,-1)),
-            list(range(51,61)),
-            ['']+list(range(68,60,-1))+[''],
-            ['']+list(range(69,77))+[''],
-            ['']*3+list(range(80,76,-1))+['']*3,
-            ],
-    "21": [['']+list(range(2,5))+[''],
-            list(range(9,4,-1)),
-            list(range(10,12))+[1]+list(range(12,14)),
-            list(range(18,13,-1)),
-            ['']+list(range(19,22))+[''],
-            ]
+    "80": [
+        [""] * 3 + list(range(2, 6)) + [""] * 3,
+        [""] + list(range(13, 5, -1)) + [""],
+        [""] + list(range(14, 22)) + [""],
+        list(range(31, 21, -1)),
+        list(range(32, 42)),
+        list(range(50, 46, -1)) + [1] + list(range(46, 41, -1)),
+        list(range(51, 61)),
+        [""] + list(range(68, 60, -1)) + [""],
+        [""] + list(range(69, 77)) + [""],
+        [""] * 3 + list(range(80, 76, -1)) + [""] * 3,
+    ],
+    "21": [
+        [""] + list(range(2, 5)) + [""],
+        list(range(9, 4, -1)),
+        list(range(10, 12)) + [1] + list(range(12, 14)),
+        list(range(18, 13, -1)),
+        [""] + list(range(19, 22)) + [""],
+    ],
 }
 
-#This carries the per-quarter variable options for stitching in quarters
-#It is prepopulated with anything we know that's size-agnostic; size-dependent
-#parameters are calculated and added by determine_final_tile_size_and_offsets
-stitched_quarter_dict = {"TopLeft":
-                         {"name":"StitchedTopLeft",
-                          "position":"Bottom-Right zero",
-                          "tile_coords_for_final_tiles":{}
-                         },
-                        "TopRight":
-                        {"name":"StitchedTopRight",
-                          "position":"Bottom-Left zero", 
-                          "tile_coords_for_final_tiles":{}
-                         },
-                        "BotLeft":
-                        {"name":"StitchedBottomLeft",
-                          "position":"Top-Right zero", 
-                          "tile_coords_for_final_tiles":{}
-                         },
-                        "BotRight":
-                        {"name":"StitchedBottomRight",
-                          "position":"Top-Left zero", 
-                          "tile_coords_for_final_tiles":{}
-                         },
-                        }
+# This carries the per-quarter variable options for stitching in quarters
+# It is prepopulated with anything we know that's size-agnostic; size-dependent
+# parameters are calculated and added by determine_final_tile_size_and_offsets
+stitched_quarter_dict = {
+    "TopLeft": {
+        "name": "StitchedTopLeft",
+        "position": "Bottom-Right zero",
+        "tile_coords_for_final_tiles": {},
+    },
+    "TopRight": {
+        "name": "StitchedTopRight",
+        "position": "Bottom-Left zero",
+        "tile_coords_for_final_tiles": {},
+    },
+    "BotLeft": {
+        "name": "StitchedBottomLeft",
+        "position": "Top-Right zero",
+        "tile_coords_for_final_tiles": {},
+    },
+    "BotRight": {
+        "name": "StitchedBottomRight",
+        "position": "Top-Left zero",
+        "tile_coords_for_final_tiles": {},
+    },
+}
 
 
 def tiffextend(imname):
-        if '.tif' in imname:
-                return imname
-        if '.' in imname:
-                return imname[:imname.index('.')]+'.tiff'
-        else:
-                return imname+'.tiff'
+    if ".tif" in imname:
+        return imname
+    if "." in imname:
+        return imname[: imname.index(".")] + ".tiff"
+    else:
+        return imname + ".tiff"
 
-def savefile(im,imname,plugin,compress='false'):
-        attemptcount = 0
-        imname = tiffextend(imname)
-        print('Saving ',imname,im.width,im.height)
-        if compress.lower()!='true':
-                IJ.saveAs(im, "tiff",imname)
-        else:
-                while attemptcount <5:
-                        try:
-                                plugin.arg="outfile="+imname+" windowless=true compression=LZW saveROI=false"
-                                exporter = Exporter(plugin, im)
-                                exporter.run()
-                                print('Succeeded after attempt ',attemptcount)
-                                return
-                        except:
-                                attemptcount +=1
-                print('failed 5 times at saving')
+
+def savefile(im, imname, plugin, compress="false"):
+    attemptcount = 0
+    imname = tiffextend(imname)
+    print("Saving ", imname, im.width, im.height)
+    if compress.lower() != "true":
+        IJ.saveAs(im, "tiff", imname)
+    else:
+        while attemptcount < 5:
+            try:
+                plugin.arg = (
+                    "outfile="
+                    + imname
+                    + " windowless=true compression=LZW saveROI=false"
+                )
+                exporter = Exporter(plugin, im)
+                exporter.run()
+                print("Succeeded after attempt ", attemptcount)
+                return
+            except:
+                attemptcount += 1
+        print("failed 5 times at saving")
 
 
 def parse_files(subdir, channame, filterstring):
@@ -163,7 +391,9 @@ def parse_files(subdir, channame, filterstring):
                 if "Overlay" not in eachfile:
                     prefix_before_well, suffix_with_well = eachfile.split("_Well_")
                     well, suffix_after_well = suffix_with_well.split("_Site_")
-                    channel_suffix = suffix_after_well[suffix_after_well.index("_") + 1 :]
+                    channel_suffix = suffix_after_well[
+                        suffix_after_well.index("_") + 1 :
+                    ]
                     if (prefix_before_well, channel_suffix) not in prefix_suffix_list:
                         prefix_suffix_list.append((prefix_before_well, channel_suffix))
                     if well not in well_list:
@@ -180,18 +410,39 @@ def parse_files(subdir, channame, filterstring):
     prefix_suffix_list.sort()
     print("final parse results", well_list, prefix_suffix_list)
     if perm_prefix is None or perm_suffix is None:
-        print("Something went wrong with parsing, couldn't find files with the channel name", channame)
-        print("Can also be caused by your filterstring", filterstring, "removing all files")
+        print(
+            "Something went wrong with parsing, couldn't find files with the channel name",
+            channame,
+        )
+        print(
+            "Can also be caused by your filterstring",
+            filterstring,
+            "removing all files",
+        )
         print("Can also be caused if images are not .tif or .tiff")
         sys.exit()
-    return dir_list, well_list,prefix_suffix_list, perm_prefix, perm_suffix
-    
-def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
-                                 perm_prefix, eachwell, perm_suffix, compress, 
-                                 out_subdir, plugin, stitched_quarter_dict, quarter = False,):
+    return dir_list, well_list, prefix_suffix_list, perm_prefix, perm_suffix
+
+
+def run_initial_stitching_per_well_section(
+    round_or_square,
+    stitchorder,
+    rows,
+    columns,
+    overlap_pct,
+    subdir,
+    perm_prefix,
+    eachwell,
+    perm_suffix,
+    compress,
+    out_subdir,
+    plugin,
+    stitched_quarter_dict,
+    quarter=False,
+):
     """Actually does the initial stitching, outputs the Tile Configuration file, no Python return.
     Could probably be refactored/shortened even further but it's probably fine."""
-    if round_or_square == 'square':
+    if round_or_square == "square":
         standard_grid_instructions = [
             "type=["
             + stitchorder
@@ -210,9 +461,7 @@ def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, c
         fileoutname = "Stitched" + filename.replace("{i}", "")
         IJ.run(
             "Grid/Collection stitching",
-            standard_grid_instructions[0]
-            + filename
-            + standard_grid_instructions[1],
+            standard_grid_instructions[0] + filename + standard_grid_instructions[1],
         )
         im = IJ.getImage()
         # We're going to overwrite this file later, but it gives is a chance for an early checkpoint
@@ -241,9 +490,7 @@ def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, c
             )
             fileoutname = "Stitched" + filename.replace("{i}", "")
             instructions = (
-                standard_grid_instructions[0]
-                + filename
-                + standard_grid_instructions[1]
+                standard_grid_instructions[0] + filename + standard_grid_instructions[1]
             )
             print(instructions)
             IJ.run("Grid/Collection stitching", instructions)
@@ -272,9 +519,9 @@ def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, c
                 + overlap_pct
                 + " first_file_index_x="
                 + str(quarter_options["first_file_index_offset_x"])
-                +" first_file_index_y="
+                + " first_file_index_y="
                 + str(quarter_options["first_file_index_offset_y"])
-                +" directory="
+                + " directory="
                 + os.path.abspath(subdir)
                 + " file_names=",
                 " output_textfile_name=TileConfiguration.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 compute_overlap computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]",
@@ -282,13 +529,11 @@ def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, c
             filename = (
                 perm_prefix + "_Well_" + eachwell + "_x_{xx}_y_{yy}_" + perm_suffix
             )
-            fileoutname = quarter_options["name"] + filename.replace("{xx}", "").replace(
-                "{yy}", ""
-            )
+            fileoutname = quarter_options["name"] + filename.replace(
+                "{xx}", ""
+            ).replace("{yy}", "")
             instructions = (
-                standard_grid_instructions[0]
-                + filename
-                + standard_grid_instructions[1]
+                standard_grid_instructions[0] + filename + standard_grid_instructions[1]
             )
             print(instructions)
             IJ.run("Grid/Collection stitching", instructions)
@@ -304,24 +549,37 @@ def run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, c
                 )
             IJ.run("Close All")
 
-def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
-                                          stitched_quarter_dict, compress, quarter = False, emptylist=None,  upscaled_row_size=0, upscaled_col_size=0):
+
+def apply_stitching_per_well_section_and_channel(
+    eachpresuf,
+    subdir,
+    round_or_square,
+    quarter_if_round,
+    tileperside,
+    tilesize,
+    stitched_quarter_dict,
+    compress,
+    quarter=False,
+    emptylist=None,
+    upscaled_row_size=0,
+    upscaled_col_size=0,
+):
     """Apply the stitching pattern calculated in run_initial_stitching_per_well to each channel for this well (or well quarter).
     For round wells where we've padded with noise tiles, uses the emptylist to remove them from the final configuration file we pass
     to the Grid/Stitch plugin, avoiding a very old bug that just dumps them on the top-left real tile.
     We make a full-sized stitch and a 10x downsampled stitch (for easy QC), then close everything and re-open the full-sized stitch
     to create a set of sub-tiled crops"""
     copy_grid_instructions = (
-            "type=[Positions from file] order=[Defined by TileConfiguration] directory="
-            + subdir
-            + " layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
-        )
-    
-    #set up
-    if round_or_square == 'square':
-            do_quarter = False
+        "type=[Positions from file] order=[Defined by TileConfiguration] directory="
+        + subdir
+        + " layout_file=TileConfiguration.registered_copy.txt fusion_method=[Linear Blending] regression_threshold=0.30 max/avg_displacement_threshold=2.50 absolute_displacement_threshold=3.50 ignore_z_stage computation_parameters=[Save computation time (but use more RAM)] image_output=[Fuse and display]"
+    )
+
+    # set up
+    if round_or_square == "square":
+        do_quarter = False
     else:
-        if quarter_if_round.lower()== "true":
+        if quarter_if_round.lower() == "true":
             do_quarter = True
         else:
             do_quarter = False
@@ -475,23 +733,15 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
         tile_subdir_persuf = os.path.join(tile_subdir, thissuffixnicename)
         if not os.path.exists(tile_subdir_persuf):
             os.mkdir(tile_subdir_persuf)
-        filename = (
-            thisprefix
-            + "_Well_"
-            + eachwell
-            + "_x_{xx}_y_{yy}_"
-            + thissuffix
+        filename = thisprefix + "_Well_" + eachwell + "_x_{xx}_y_{yy}_" + thissuffix
+        fileoutname = quarter_options["name"] + filename.replace("{xx}", "").replace(
+            "{yy}", ""
         )
-        fileoutname = quarter_options["name"] + filename.replace(
-            "{xx}", ""
-        ).replace("{yy}", "")
         with open(
             os.path.join(subdir, "TileConfiguration.registered.txt"), "r"
         ) as infile:
             with open(
-                os.path.join(
-                    subdir, "TileConfiguration.registered_copy.txt"
-                ),
+                os.path.join(subdir, "TileConfiguration.registered_copy.txt"),
                 "w",
             ) as outfile:
                 for line in infile:
@@ -504,10 +754,10 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
         im0 = IJ.getImage()
         # chop off the opposite edige
         IJ.makeRectangle(
-            quarter_options["crop_numerical_position"][0], 
-            quarter_options["crop_numerical_position"][1], 
-            im0.width + quarter_options["crop_numerical_position"][2], 
-            im0.height + quarter_options["crop_numerical_position"][3]
+            quarter_options["crop_numerical_position"][0],
+            quarter_options["crop_numerical_position"][1],
+            im0.width + quarter_options["crop_numerical_position"][2],
+            im0.height + quarter_options["crop_numerical_position"][3],
         )
         im1 = im0.crop()
         width = str(int(round(im1.width * float(scalingstring))))
@@ -544,7 +794,8 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
             + str(upscaled_col_size)
             + " height="
             + str(upscaled_row_size)
-            + " position="+quarter_options["position"],
+            + " position="
+            + quarter_options["position"],
         )
         IJ.run(
             "Canvas Size...",
@@ -552,7 +803,8 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
             + str(upscaled_col_size)
             + " height="
             + str(upscaled_row_size)
-            + " position="+quarter_options["position"],
+            + " position="
+            + quarter_options["position"],
         )
         time.sleep(15)
         im3 = IJ.getImage()
@@ -618,8 +870,9 @@ def apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_squ
             )
         IJ.run("Close All")
 
+
 def get_round_rows_cols(im_per_well_dict, phenix_im_per_well_dict, imperwell, phenix):
-    if not phenix: #assume we snake back and forth, like a sane microscope
+    if not phenix:  # assume we snake back and forth, like a sane microscope
         try:
             row_widths = im_per_well_dict[imperwell]
             rows = str(len(row_widths))
@@ -627,26 +880,38 @@ def get_round_rows_cols(im_per_well_dict, phenix_im_per_well_dict, imperwell, ph
         except:
             print(imperwell, "images/well for a round well is not currently supported")
             sys.exit()
-        
+
     else:
-        try: 
+        try:
             row_pattern = phenix_im_per_well_dict[imperwell]
             row_widths = range(len(row_pattern))
             column_widths = range(len(row_pattern[0]))
             rows = str(len(row_widths))
             columns = str(len(column_widths))
         except:
-            print(imperwell, "images/well for a round Phenix well is not currently supported")
+            print(
+                imperwell,
+                "images/well for a round Phenix well is not currently supported",
+            )
             sys.exit()
     return rows, columns
-        
-def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwell,size,
-                      well_list, prefix_suffix_list, subdir, phenix=False):
+
+
+def map_and_rename_round_wells(
+    im_per_well_dict,
+    phenix_im_per_well_dict,
+    imperwell,
+    size,
+    well_list,
+    prefix_suffix_list,
+    subdir,
+    phenix=False,
+):
     """Makes the new blank file and the renamed files, return the empty list of things that won't align"""
     pos_dict = {}
-    emptylist = [] 
+    emptylist = []
 
-    if not phenix: #assume we snake back and forth, like a sane microscope
+    if not phenix:  # assume we snake back and forth, like a sane microscope
         row_widths = im_per_well_dict[imperwell]
         try:
             rows = str(len(row_widths))
@@ -667,7 +932,7 @@ def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwel
         except:
             print("failed at trying to create position dict from images per well")
             sys.exit()
-    else: #since the Phenix, due to its initial center position, isn't easy to mathematically model, we just had to hardcode the positions
+    else:  # since the Phenix, due to its initial center position, isn't easy to mathematically model, we just had to hardcode the positions
         row_pattern = phenix_im_per_well_dict[imperwell]
 
         try:
@@ -681,11 +946,11 @@ def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwel
                     if siteval != "":
                         pos_dict[(col, row)] = str(siteval)
         except:
-            print("failed at trying to create position dict from images per well") 
+            print("failed at trying to create position dict from images per well")
             sys.exit()
 
     filled_positions = pos_dict.keys()
-    #print(os.listdir('.'),os.listdir(subdir))
+    # print(os.listdir('.'),os.listdir(subdir))
     for eachwell in well_list:
         for eachpresuf in prefix_suffix_list:
             thisprefix, thissuffix = eachpresuf
@@ -703,7 +968,7 @@ def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwel
                         + thissuffix
                     )
                     if (x, y) in filled_positions:
-                        #Note- if we ever decide to not have renamed things (ie, not illum correct barcode), work is needed here
+                        # Note- if we ever decide to not have renamed things (ie, not illum correct barcode), work is needed here
                         series = pos_dict[(x, y)]
                         in_name = (
                             thisprefix
@@ -714,11 +979,9 @@ def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwel
                             + "_"
                             + thissuffix
                         )
-                        IJ.open(os.path.abspath(os.path.join(subdir,in_name)))
+                        IJ.open(os.path.abspath(os.path.join(subdir, in_name)))
                     else:
-                        IJ.newImage(
-                            "Untitled", "16-bit noise", int(size), int(size), 1
-                        )
+                        IJ.newImage("Untitled", "16-bit noise", int(size), int(size), 1)
                         IJ.run(
                             "Divide...", "value=100"
                         )  # get the noise value below the real camera noise level
@@ -744,20 +1007,29 @@ def map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwel
         print("first ten images in imagelist", imagelist[:10])
         return emptylist, rows, columns
 
-def determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, columns, 
-                                          stitched_quarter_dict, final_tile_size, yoffset_tiles=0, xoffset_tiles=0):
+
+def determine_final_tile_size_and_offsets(
+    tileperside,
+    scalingstring,
+    rows,
+    columns,
+    stitched_quarter_dict,
+    final_tile_size,
+    yoffset_tiles=0,
+    xoffset_tiles=0,
+):
     """Return final parameters for how many tiles we're going to have, and what sizes they'll be.
-    
+
     For cases where we're quartering a large round well, it also does the crop determination;
     this includes the first_file_offset indices passed to GridStitcher (so that it knows and expects
     to stitch e.g. only columns 6-10 rather than 1-5) and human-determined offsets which alter where the
-    lines between parts of the circle are drawn (rare, implmented I THINK mostly for alignment issues if 
-    I recall correctly, which I may not). """
+    lines between parts of the circle are drawn (rare, implmented I THINK mostly for alignment issues if
+    I recall correctly, which I may not)."""
 
     tileperside = int(tileperside)
     scale_factor = float(scalingstring)
     rounded_scale_factor = int(round(scale_factor))
-    if round_or_square == 'square':
+    if round_or_square == "square":
         stitchedsize = int(rows) * int(size)
         upscaled_row_size = int(stitchedsize * rounded_scale_factor)
         if upscaled_row_size > 46340:
@@ -784,65 +1056,100 @@ def determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, colum
         if tilesize * tiles_per_quarter > upscaled_row_size:
             upscaled_row_size = tilesize * tiles_per_quarter
         upscaled_col_size = upscaled_row_size
-        tile_offset = upscaled_row_size - (tilesize * tiles_per_quarter) #I'm not sure how this works? 
-        pixels_to_crop = int(round(int(size) * float(overlap_pct) / 200)) #I'm not sure how this works either?
+        tile_offset = upscaled_row_size - (
+            tilesize * tiles_per_quarter
+        )  # I'm not sure how this works?
+        pixels_to_crop = int(
+            round(int(size) * float(overlap_pct) / 200)
+        )  # I'm not sure how this works either?
 
-        #top left
+        # top left
         stitched_quarter_dict["TopLeft"]["grid_size_x"] = left_columns
         stitched_quarter_dict["TopLeft"]["grid_size_y"] = top_rows
-        stitched_quarter_dict["TopLeft"]["crop_numerical_position"] = [0,0,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["TopLeft"]["crop_numerical_position"] = [
+            0,
+            0,
+            -pixels_to_crop,
+            -pixels_to_crop,
+        ]
         stitched_quarter_dict["TopLeft"]["first_file_index_offset_x"] = 0
         stitched_quarter_dict["TopLeft"]["first_file_index_offset_y"] = 0
         for eachxtile in range(tiles_per_quarter):
             for eachytile in range(tiles_per_quarter):
-                each_tile_num = eachxtile*int(tileperside) + eachytile + 1
-                stitched_quarter_dict["TopLeft"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize)+tile_offset, (eachytile*tilesize)+tile_offset)
-        #top right
+                each_tile_num = eachxtile * int(tileperside) + eachytile + 1
+                stitched_quarter_dict["TopLeft"]["tile_coords_for_final_tiles"][
+                    each_tile_num
+                ] = (
+                    (eachxtile * tilesize) + tile_offset,
+                    (eachytile * tilesize) + tile_offset,
+                )
+        # top right
         stitched_quarter_dict["TopRight"]["grid_size_x"] = right_columns
         stitched_quarter_dict["TopRight"]["grid_size_y"] = top_rows
-        stitched_quarter_dict["TopRight"]["crop_numerical_position"] = [pixels_to_crop,0,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["TopRight"]["crop_numerical_position"] = [
+            pixels_to_crop,
+            0,
+            -pixels_to_crop,
+            -pixels_to_crop,
+        ]
         stitched_quarter_dict["TopRight"]["first_file_index_offset_x"] = left_columns
         stitched_quarter_dict["TopRight"]["first_file_index_offset_y"] = 0
         for eachxtile in range(tiles_per_quarter):
             for eachytile in range(tiles_per_quarter):
                 each_tile_num = (
-                                int(tiles_per_quarter) * int(tileperside)
-                                + eachxtile * int(tileperside)
-                                + eachytile
-                                + 1
-                            )
-                stitched_quarter_dict["TopRight"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize), (eachytile*tilesize)+tile_offset)
-        #bot left
+                    int(tiles_per_quarter) * int(tileperside)
+                    + eachxtile * int(tileperside)
+                    + eachytile
+                    + 1
+                )
+                stitched_quarter_dict["TopRight"]["tile_coords_for_final_tiles"][
+                    each_tile_num
+                ] = ((eachxtile * tilesize), (eachytile * tilesize) + tile_offset)
+        # bot left
         stitched_quarter_dict["BotLeft"]["grid_size_x"] = left_columns
         stitched_quarter_dict["BotLeft"]["grid_size_y"] = bot_rows
-        stitched_quarter_dict["BotLeft"]["crop_numerical_position"] = [0,pixels_to_crop,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["BotLeft"]["crop_numerical_position"] = [
+            0,
+            pixels_to_crop,
+            -pixels_to_crop,
+            -pixels_to_crop,
+        ]
         stitched_quarter_dict["BotLeft"]["first_file_index_offset_x"] = 0
-        stitched_quarter_dict["BotLeft"]["first_file_index_offset_y"] = top_rows 
+        stitched_quarter_dict["BotLeft"]["first_file_index_offset_y"] = top_rows
         for eachxtile in range(tiles_per_quarter):
             for eachytile in range(tiles_per_quarter):
                 each_tile_num = (
-                                eachxtile * int(tileperside)
-                                + int(tiles_per_quarter)
-                                + eachytile
-                                + 1
-                            )
-                stitched_quarter_dict["BotLeft"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile*tilesize)+tile_offset, (eachytile*tilesize))
-        #bot right
+                    eachxtile * int(tileperside)
+                    + int(tiles_per_quarter)
+                    + eachytile
+                    + 1
+                )
+                stitched_quarter_dict["BotLeft"]["tile_coords_for_final_tiles"][
+                    each_tile_num
+                ] = ((eachxtile * tilesize) + tile_offset, (eachytile * tilesize))
+        # bot right
         stitched_quarter_dict["BotRight"]["grid_size_x"] = right_columns
         stitched_quarter_dict["BotRight"]["grid_size_y"] = bot_rows
-        stitched_quarter_dict["BotRight"]["crop_numerical_position"] = [pixels_to_crop,pixels_to_crop,-pixels_to_crop,-pixels_to_crop]
+        stitched_quarter_dict["BotRight"]["crop_numerical_position"] = [
+            pixels_to_crop,
+            pixels_to_crop,
+            -pixels_to_crop,
+            -pixels_to_crop,
+        ]
         stitched_quarter_dict["BotRight"]["first_file_index_offset_x"] = left_columns
         stitched_quarter_dict["BotRight"]["first_file_index_offset_y"] = top_rows
         for eachxtile in range(tiles_per_quarter):
             for eachytile in range(tiles_per_quarter):
                 each_tile_num = each_tile_num = (
-                                int(tiles_per_quarter) * int(tileperside)
-                                + eachxtile * int(tileperside)
-                                + int(tiles_per_quarter)
-                                + eachytile
-                                + 1
-                            )
-                stitched_quarter_dict["BotRight"]["tile_coords_for_final_tiles"][each_tile_num] = ((eachxtile * tilesize),(eachytile * tilesize))
+                    int(tiles_per_quarter) * int(tileperside)
+                    + eachxtile * int(tileperside)
+                    + int(tiles_per_quarter)
+                    + eachytile
+                    + 1
+                )
+                stitched_quarter_dict["BotRight"]["tile_coords_for_final_tiles"][
+                    each_tile_num
+                ] = ((eachxtile * tilesize), (eachytile * tilesize))
 
     else:
         max_val = max(int(rows), int(columns))
@@ -851,58 +1158,129 @@ def determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, colum
             upscaled_row_size = tilesize * tileperside
         upscaled_col_size = upscaled_row_size
         pixels_to_crop = None
-    
-    return tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor
+
+    return (
+        tilesize,
+        upscaled_row_size,
+        upscaled_col_size,
+        pixels_to_crop,
+        stitched_quarter_dict,
+        scale_factor,
+    )
+
 
 # ACTUAL CODE TO RUN STARTS HERE, EVERYTHING ABOVE COULD BE A UTIL
 
 # Define and create the folders where the images will be output
-out_subdir = 'stitched_images'
-tile_subdir = 'cropped_images'
-downsample_subdir = 'downsampled_images'
+out_subdir = "stitched_images"
+tile_subdir = "cropped_images"
+downsample_subdir = "downsampled_images"
 
 if not os.path.exists(out_subdir):
-        os.mkdir(out_subdir)
+    os.mkdir(out_subdir)
 if not os.path.exists(tile_subdir):
-        os.mkdir(tile_subdir)
+    os.mkdir(tile_subdir)
 if not os.path.exists(downsample_subdir):
-        os.mkdir(downsample_subdir)
+    os.mkdir(downsample_subdir)
 
-subdir=os.path.join(input_file_location,subdir)
+subdir = os.path.join(input_file_location, subdir)
 
 if os.path.isdir(subdir):
-    dir_list, well_list, prefix_suffix_list, perm_prefix, perm_suffix = parse_files(subdir, channame, filterstring)
+    dir_list, well_list, prefix_suffix_list, perm_prefix, perm_suffix = parse_files(
+        subdir, channame, filterstring
+    )
 
     # Measure actual image size from the first file
-    first_image_path = os.path.join(subdir, perm_prefix + "_Well_" + well_list[0] + "_Site_1_" + perm_suffix)
+    first_image_path = os.path.join(
+        subdir, perm_prefix + "_Well_" + well_list[0] + "_Site_1_" + perm_suffix
+    )
     imp = IJ.openImage(first_image_path)
     size = str(imp.getWidth())
     imp.close()
 
-    if round_or_square == "round": # We usually infer rows and columns from the im_per_well_dict for round
-        do_phenix = phenix.lower()=="true"
-        rows, columns = get_round_rows_cols(im_per_well_dict, phenix_im_per_well_dict, imperwell, phenix = do_phenix)
-    
-    #Get final sizes for things, including all random funky offsets
-    tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor = determine_final_tile_size_and_offsets(tileperside,scalingstring, rows, columns, 
-                                        stitched_quarter_dict, final_tile_size, yoffset_tiles=yoffset_tiles, xoffset_tiles=xoffset_tiles)
-    
-    print("finished the parsing",tilesize, upscaled_row_size, upscaled_col_size, pixels_to_crop, stitched_quarter_dict, scale_factor)
+    if (
+        round_or_square == "round"
+    ):  # We usually infer rows and columns from the im_per_well_dict for round
+        do_phenix = phenix.lower() == "true"
+        rows, columns = get_round_rows_cols(
+            im_per_well_dict, phenix_im_per_well_dict, imperwell, phenix=do_phenix
+        )
+
+    # Get final sizes for things, including all random funky offsets
+    (
+        tilesize,
+        upscaled_row_size,
+        upscaled_col_size,
+        pixels_to_crop,
+        stitched_quarter_dict,
+        scale_factor,
+    ) = determine_final_tile_size_and_offsets(
+        tileperside,
+        scalingstring,
+        rows,
+        columns,
+        stitched_quarter_dict,
+        final_tile_size,
+        yoffset_tiles=yoffset_tiles,
+        xoffset_tiles=xoffset_tiles,
+    )
+
+    print(
+        "finished the parsing",
+        tilesize,
+        upscaled_row_size,
+        upscaled_col_size,
+        pixels_to_crop,
+        stitched_quarter_dict,
+        scale_factor,
+    )
     if round_or_square == "square":
         for eachwell in well_list:
-            run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
-                                perm_prefix, eachwell, perm_suffix, compress, out_subdir, plugin, stitched_quarter_dict, quarter = False,)
+            run_initial_stitching_per_well_section(
+                round_or_square,
+                stitchorder,
+                rows,
+                columns,
+                overlap_pct,
+                subdir,
+                perm_prefix,
+                eachwell,
+                perm_suffix,
+                compress,
+                out_subdir,
+                plugin,
+                stitched_quarter_dict,
+                quarter=False,
+            )
             for eachpresuf in prefix_suffix_list:  # for each channel
-                apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
-                                stitched_quarter_dict, compress, upscaled_row_size=upscaled_row_size, upscaled_col_size=upscaled_col_size)
+                apply_stitching_per_well_section_and_channel(
+                    eachpresuf,
+                    subdir,
+                    round_or_square,
+                    quarter_if_round,
+                    tileperside,
+                    tilesize,
+                    stitched_quarter_dict,
+                    compress,
+                    upscaled_row_size=upscaled_row_size,
+                    upscaled_col_size=upscaled_col_size,
+                )
     elif round_or_square == "round":
         # do renaming and mapping of where each position is
-        # Since the Grid/Collection plugin requires squares, this also makes empty tiles 
+        # Since the Grid/Collection plugin requires squares, this also makes empty tiles
         # at the edges to pad the circle into a square
-        emptylist, rows, columns = map_and_rename_round_wells(im_per_well_dict,phenix_im_per_well_dict,imperwell,size,
-                      well_list, prefix_suffix_list, subdir, phenix=do_phenix)
-        
-        #The mapper doesn't know what the permament prefix and suffix are, so we'll subset this for speed
+        emptylist, rows, columns = map_and_rename_round_wells(
+            im_per_well_dict,
+            phenix_im_per_well_dict,
+            imperwell,
+            size,
+            well_list,
+            prefix_suffix_list,
+            subdir,
+            phenix=do_phenix,
+        )
+
+        # The mapper doesn't know what the permament prefix and suffix are, so we'll subset this for speed
         print("perm_prefix", perm_prefix)
         print("perm_suffix", perm_suffix)
         print("emptylist before subsetting", emptylist)
@@ -910,23 +1288,75 @@ if os.path.isdir(subdir):
         print("emptylist after subsetting", emptylist)
 
         for eachwell in well_list:
-            if quarter_if_round.lower() == "false": #The whole well should be stitched
-                run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
-                                perm_prefix, eachwell, perm_suffix, compress, 
-                                out_subdir, plugin, stitched_quarter_dict, quarter = False,)
+            if quarter_if_round.lower() == "false":  # The whole well should be stitched
+                run_initial_stitching_per_well_section(
+                    round_or_square,
+                    stitchorder,
+                    rows,
+                    columns,
+                    overlap_pct,
+                    subdir,
+                    perm_prefix,
+                    eachwell,
+                    perm_suffix,
+                    compress,
+                    out_subdir,
+                    plugin,
+                    stitched_quarter_dict,
+                    quarter=False,
+                )
                 # cropping
                 for eachpresuf in prefix_suffix_list:  # for each channel
-                    apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize, 
-                                stitched_quarter_dict, compress, emptylist=emptylist, upscaled_row_size=upscaled_row_size, upscaled_col_size=upscaled_col_size)
+                    apply_stitching_per_well_section_and_channel(
+                        eachpresuf,
+                        subdir,
+                        round_or_square,
+                        quarter_if_round,
+                        tileperside,
+                        tilesize,
+                        stitched_quarter_dict,
+                        compress,
+                        emptylist=emptylist,
+                        upscaled_row_size=upscaled_row_size,
+                        upscaled_col_size=upscaled_col_size,
+                    )
             else:
-                for quarter in stitched_quarter_dict.keys(): #The well is over Fiji's max size limit, so we'll stitch in quarters
-                    run_initial_stitching_per_well_section(round_or_square, stitchorder, rows, columns, overlap_pct, subdir, 
-                                perm_prefix, eachwell, perm_suffix, compress, 
-                                out_subdir, plugin, stitched_quarter_dict, quarter = quarter)
+                for (
+                    quarter
+                ) in (
+                    stitched_quarter_dict.keys()
+                ):  # The well is over Fiji's max size limit, so we'll stitch in quarters
+                    run_initial_stitching_per_well_section(
+                        round_or_square,
+                        stitchorder,
+                        rows,
+                        columns,
+                        overlap_pct,
+                        subdir,
+                        perm_prefix,
+                        eachwell,
+                        perm_suffix,
+                        compress,
+                        out_subdir,
+                        plugin,
+                        stitched_quarter_dict,
+                        quarter=quarter,
+                    )
                     for eachpresuf in prefix_suffix_list:
-                        apply_stitching_per_well_section_and_channel(eachpresuf, subdir,round_or_square,quarter_if_round, tileperside,tilesize,
-                                stitched_quarter_dict, compress, quarter = quarter, emptylist=emptylist, upscaled_row_size=upscaled_row_size, 
-                                upscaled_col_size=upscaled_col_size)
+                        apply_stitching_per_well_section_and_channel(
+                            eachpresuf,
+                            subdir,
+                            round_or_square,
+                            quarter_if_round,
+                            tileperside,
+                            tilesize,
+                            stitched_quarter_dict,
+                            compress,
+                            quarter=quarter,
+                            emptylist=emptylist,
+                            upscaled_row_size=upscaled_row_size,
+                            upscaled_col_size=upscaled_col_size,
+                        )
 
     else:
         print("Must identify well as round or square")

--- a/assets/stitchcrop/stitch_crop.env_master.test_profile.py
+++ b/assets/stitchcrop/stitch_crop.env_master.test_profile.py
@@ -25,7 +25,7 @@ final_tile_size = os.getenv("FINAL_TILE_SIZE", "2960")
 xoffset_tiles = os.getenv("XOFFSET_TILES", "0")
 yoffset_tiles = os.getenv("YOFFSET_TILES", "0")
 compress = os.getenv("COMPRESS", "True")
-first_site_index = os.getenv("FIRST_SITE_INDEX", "0")
+first_site_index = os.getenv("FIRST_SITE_INDEX", "1")
 
 from ij import IJ, WindowManager
 import os

--- a/bin/generate_load_data_csv.py
+++ b/bin/generate_load_data_csv.py
@@ -79,7 +79,7 @@ PIPELINE_CONFIGS = {
     },
     'combined': {
         'description': 'Combined analysis - uses both cropped cell painting and barcoding images',
-        'file_pattern': r'(Plate_.*_Well_.*_Site_.*_Corr.*\.(?:tiff?|nd2)|Plate_.*_Well_.*_Site_.*_Cycle\d{2}_\w+\.(?:tiff?|nd2)|Plate\d+-[A-Z]\d+_Corr.*_Site_\d+\.(?:tiff?|nd2)|Plate\d+-[A-Z]\d+_Cycle\d+_\w+_Site_\d+\.(?:tiff?|nd2))$',
+        'file_pattern': r'(Corr\w+_Plate_.*_Well_.*_Site_.*\.(?:tiff?|nd2)|Cycle\d{2}_\w+_Plate_.*_Well_.*_Site_.*\.(?:tiff?|nd2)|Plate_.*_Well_.*_Site_.*_Corr.*\.(?:tiff?|nd2)|Plate_.*_Well_.*_Site_.*_Cycle\d{2}_\w+\.(?:tiff?|nd2)|Plate\d+-[A-Z]\d+_Corr.*_Site_\d+\.(?:tiff?|nd2)|Plate\d+-[A-Z]\d+_Cycle\d+_\w+_Site_\d+\.(?:tiff?|nd2))$',
         'metadata_cols': ['Metadata_Plate', 'Metadata_Site', 'Metadata_Well', 'Metadata_Well_Value'],
         'include_illum_files': False,
         'parse_function': 'parse_combined_image'

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -116,7 +116,7 @@ def merge_csvs(csvfolder, filename, column_list=None, backup_list=None, filter_s
                         os.path.join(csvfolder, eachfolder, filename),
                         index_col=False,
                         usecols=backup_list,
-                    )                    
+                    )
             count += 1
             if count % 500 == 0:
                 print(count, datetime.datetime.ctime(datetime.datetime.now()))
@@ -149,7 +149,7 @@ if os.path.isfile(test_file):
         print("Detected channel naming convention: DAPI")
     else:
         print(f"Could not detect channel naming convention, defaulting to {channel_name}")
-    
+
     orig_cols = [x for x in test_df.columns if "Correlation_Correlation" in x and "Orig" in x]
     MI_cols = [x for x in test_df.columns if "MI" in x and channel_name in x]
     print (f"Detected {len(MI_cols)} MI columns for channel {channel_name}")
@@ -475,12 +475,12 @@ def make_plot(df):
         # Extract the cycle number (e.g., 'Cycle02')
         cycle_match = re.search(r'(Cycle\d+)', col, flags=re.IGNORECASE)
         cycle_num = cycle_match.group(1) if cycle_match else "Unknown"
-        
+
         # Grab just this column
         temp_df = df[[col]].copy()
         temp_df.columns = ['ARI_Value'] # Standardize the column name
         temp_df['Cycle'] = cycle_num    # Add the category label
-        
+
         records.append(temp_df)
     # Combine into a single long DataFrame
     plot_df = pd.concat(records, ignore_index=True)
@@ -496,11 +496,11 @@ def make_plot(df):
     )
 
     min_val = plot_df['ARI_Value'].min()
-    plt.axhline(y=min_val, color='blue', linestyle='--', linewidth=1.5, 
+    plt.axhline(y=min_val, color='blue', linestyle='--', linewidth=1.5,
                 label=f'Global Minimum ({min_val:.3f})')
-    plt.axhline(y=0.8, color='red', linestyle='--', linewidth=1.5, 
+    plt.axhline(y=0.8, color='red', linestyle='--', linewidth=1.5,
                 label=f'QC Threshold (0.8)')
-    plt.legend(loc='lower right') 
+    plt.legend(loc='lower right')
 
     # Lock Y-axis to 0-1
     plt.ylim(0, 1)

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -23,6 +23,7 @@
 # %%
 import os
 from pathlib import Path
+import re
 import pandas as pd
 import seaborn as sns
 import datetime
@@ -154,6 +155,8 @@ if os.path.isfile(test_file):
     print (f"Detected {len(MI_cols)} MI columns for channel {channel_name}")
     debris_cols = [x for x in test_df.columns if "Count_Debris" in x]
     print (f"Detected {len(debris_cols)} debris columns")
+    OL_cols = [x for x in test_df.columns if "Overlap_Recall" in x]
+    print (f"Detected {len(OL_cols)} Overlap_Recall columns")
 
 # Build column lists using detected channel name
 shift_list = []
@@ -170,8 +173,8 @@ shift_list_MI = [x for x in MI_cols if "Align_Xshift_Cycle" in x or "Align_Yshif
 corr_list_MI = [x for x in MI_cols if "Correlation_Correlation_Cycle" in x]
 
 id_list = ["Metadata_Well", "Metadata_Plate", "Metadata_Site"]
-column_list_with_MI = id_list + shift_list + corr_list + shift_list_MI + corr_list_MI + debris_cols + orig_cols
-column_list_no_MI = id_list + shift_list + corr_list + debris_cols + orig_cols
+column_list = list(set(id_list + shift_list + corr_list + shift_list_MI + corr_list_MI + debris_cols + orig_cols + OL_cols))
+
 
 # Load data with caching support
 if use_cache and cache_file.exists():
@@ -181,7 +184,7 @@ if use_cache and cache_file.exists():
 else:
     print(f"Loading data from: {csvfolder}")
     df_image = merge_csvs(
-        csvfolder, "BarcodingApplication_Image.csv", column_list=column_list_with_MI, backup_list=column_list_no_MI, filter_string=None
+        csvfolder, "BarcodingApplication_Image.csv", column_list=column_list, backup_list=None, filter_string=None
     )
 
     print(f"Loaded {len(df_image)} rows")
@@ -463,6 +466,51 @@ print(
 
 df_shift.loc[df_shift["value"] > 100].sort_values(by="value", ascending=False).head(20)
 
+# %%
+# Alignment quality using thresholding
+# Handles well edge much better than image correlation
+def make_plot(df):
+    records = []
+    for col in df.columns:
+        # Extract the cycle number (e.g., 'Cycle02')
+        cycle_match = re.search(r'(Cycle\d+)', col, flags=re.IGNORECASE)
+        cycle_num = cycle_match.group(1) if cycle_match else "Unknown"
+        
+        # Grab just this column
+        temp_df = df[[col]].copy()
+        temp_df.columns = ['ARI_Value'] # Standardize the column name
+        temp_df['Cycle'] = cycle_num    # Add the category label
+        
+        records.append(temp_df)
+    # Combine into a single long DataFrame
+    plot_df = pd.concat(records, ignore_index=True)
+
+    plt.figure(figsize=(12, 6))
+
+    sns.stripplot(
+        data=plot_df,
+        x='Cycle',
+        y='ARI_Value',
+        alpha=0.7,
+        legend=False      # Legend is redundant since the X-axis already labels the cycles
+    )
+
+    min_val = plot_df['ARI_Value'].min()
+    plt.axhline(y=min_val, color='blue', linestyle='--', linewidth=1.5, 
+                label=f'Global Minimum ({min_val:.3f})')
+    plt.axhline(y=0.8, color='red', linestyle='--', linewidth=1.5, 
+                label=f'QC Threshold (0.8)')
+    plt.legend(loc='lower right') 
+
+    # Lock Y-axis to 0-1
+    plt.ylim(0, 1)
+    plt.ylabel('Overlap Recall')
+
+    plt.tight_layout()
+    plt.show()
+if OL_cols:
+    make_plot(df_image[[x for x in OL_cols if 'MI' not in x]])
+
 # %% [markdown]
 # ## Pixel Shifts Analysis - MI ALIGNMENT METHOD
 #
@@ -643,3 +691,7 @@ if MI_cols:
     )
 
     df_shift_MI.loc[df_shift_MI["value"] > 100].sort_values(by="value", ascending=False).head(20)
+
+# %
+if OL_cols:
+    make_plot(df_image[[x for x in OL_cols if 'MI' in x]])

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -693,5 +693,5 @@ if MI_cols:
     df_shift_MI.loc[df_shift_MI["value"] > 100].sort_values(by="value", ascending=False).head(20)
 
 # %
-if OL_cols:
+if OL_cols and MI_cols:
     make_plot(df_image[[x for x in OL_cols if 'MI' in x]])

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -192,6 +192,8 @@ else:
     print("Cache saved")
 
 # Check if MI alignment was used
+has_MI = False
+has_debris = False
 if any(col in df_image.columns for col in shift_list_MI):
     has_MI = True
 if any([x for x in df_image.columns if 'Debris' in x]):

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -85,7 +85,7 @@ elif row_widths:
 
 
 # %%
-def merge_csvs(csvfolder, filename, column_list=None, filter_string=None):
+def merge_csvs(csvfolder, filename, column_list=None, backup_list=None, filter_string=None):
     """
     Merge CSV files from multiple subdirectories.
 
@@ -104,11 +104,18 @@ def merge_csvs(csvfolder, filename, column_list=None, filter_string=None):
                     os.path.join(csvfolder, eachfolder, filename), index_col=False
                 )
             else:
-                df_dict[eachfolder] = pd.read_csv(
-                    os.path.join(csvfolder, eachfolder, filename),
-                    index_col=False,
-                    usecols=column_list,
-                )
+                try:
+                    df_dict[eachfolder] = pd.read_csv(
+                        os.path.join(csvfolder, eachfolder, filename),
+                        index_col=False,
+                        usecols=column_list,
+                    )
+                except:
+                    df_dict[eachfolder] = pd.read_csv(
+                        os.path.join(csvfolder, eachfolder, filename),
+                        index_col=False,
+                        usecols=backup_list,
+                    )                    
             count += 1
             if count % 500 == 0:
                 print(count, datetime.datetime.ctime(datetime.datetime.now()))
@@ -145,17 +152,25 @@ for folder in folderlist:
 
 # Build column lists using detected channel name
 shift_list = []
+shift_list_MI = []
 corr_list = []
+corr_list_MI = []
 for cycle in range(1, numcycles + 1):
     if cycle != 1:
         shift_list.append(f"Align_Xshift_Cycle{cycle:02d}_{channel_name}")
         shift_list.append(f"Align_Yshift_Cycle{cycle:02d}_{channel_name}")
+        shift_list_MI.append(f"Align_Xshift_Cycle{cycle:02d}_{channel_name}_MI")
+        shift_list_MI.append(f"Align_Yshift_Cycle{cycle:02d}_{channel_name}_MI")
     for cycle2 in range(cycle + 1, numcycles + 1):
         corr_list.append(
             f"Correlation_Correlation_Cycle{cycle:02d}_{channel_name}_Cycle{cycle2:02d}_{channel_name}"
         )
+        corr_list_MI.append(
+            f"Correlation_Correlation_Cycle{cycle:02d}_{channel_name}_Cycle{cycle2:02d}_{channel_name}_MI"
+        )
 id_list = ["Metadata_Well", "Metadata_Plate", "Metadata_Site"]
-column_list = id_list + shift_list + corr_list
+column_list_with_MI = id_list + shift_list + corr_list + shift_list_MI + corr_list_MI
+column_list_no_MI = id_list + shift_list + corr_list
 
 # Load data with caching support
 if use_cache and cache_file.exists():
@@ -164,12 +179,8 @@ if use_cache and cache_file.exists():
     print(f"Loaded {len(df_image)} rows from cache")
 else:
     print(f"Loading data from: {csvfolder}")
-    print(
-        f"Columns to extract: {len(column_list)} ({len(shift_list)} shifts, {len(corr_list)} correlations)"
-    )
-
     df_image = merge_csvs(
-        csvfolder, "BarcodingApplication_Image.csv", column_list, filter_string=None
+        csvfolder, "BarcodingApplication_Image.csv", column_list=column_list_with_MI, backup_list=column_list_no_MI, filter_string=None
     )
 
     print(f"Loaded {len(df_image)} rows")
@@ -179,6 +190,12 @@ else:
     print(f"Caching data to: {cache_file}")
     df_image.to_parquet(cache_file, compression="gzip", index=False)
     print("Cache saved")
+
+# Check if MI alignment was used
+if any(col in df_image.columns for col in shift_list_MI):
+    has_MI = True
+if any([x for x in df_image.columns if 'Debris' in x]):
+    has_debris = True
 
 # Detect site numbering convention (0-based or 1-based)
 min_site = df_image["Metadata_Site"].min()
@@ -203,7 +220,7 @@ if imperwell is None:
 # Only create position mapping if geometry is provided
 pos_df = None
 
-if rows and columns:
+if rows and columns: #TODO rows and columns now required for circular too. need to update.
     # Square/rectangular acquisition
     print(f"Creating square position mapping: {rows}x{columns}")
     pos_data = []
@@ -259,6 +276,13 @@ df_corr = df_image[corr_list + id_list]
 df_corr = pd.melt(df_corr, id_vars=id_list)
 df_corr_crop = df_image[[x for x in corr_list if "Correlation_Cycle01" in x] + id_list]
 df_corr_crop = pd.melt(df_corr_crop, id_vars=id_list)
+if has_MI:
+    df_shift_MI = df_image[shift_list_MI + id_list]
+    df_shift_MI = pd.melt(df_shift_MI, id_vars=id_list)
+    df_corr_MI = df_image[corr_list_MI + id_list]
+    df_corr_MI = pd.melt(df_corr_MI, id_vars=id_list)
+    df_corr_crop_MI = df_image[[x for x in corr_list_MI if "Correlation_Cycle01" in x] + id_list]
+    df_corr_crop_MI = pd.melt(df_corr_crop_MI, id_vars=id_list)
 
 print("Prepared data:")
 print(f"  Shifts: {len(df_shift)} rows")
@@ -266,7 +290,7 @@ print(f"  All correlations: {len(df_corr)} rows")
 print(f"  Cycle01 correlations: {len(df_corr_crop)} rows")
 
 # %% [markdown]
-# ## Pixel Shifts Analysis
+# ## Pixel Shifts Analysis - ORIGINAL NCC ALIGNMENT METHOD
 #
 # ### Pixels shifted to align each cycle to Cycle01 (no axis limits)
 
@@ -359,7 +383,7 @@ else:
     print("Skipping spatial plot - no geometry provided")
 
 # %% [markdown]
-# ## Correlation Analysis
+# ## Correlation Analysis - ORIGINAL NCC ALIGNMENT METHOD
 #
 # ### DAPI correlations after alignment (all pairwise comparisons)
 #
@@ -382,7 +406,7 @@ plt.savefig(
 plt.show()
 
 # %% [markdown]
-# ### DAPI correlations after alignment (only correlations to Cycle01)
+# ### DAPI correlations after alignment (only correlations to Cycle01) - ORIGINAL NCC ALIGNMENT METHOD
 #
 # Need all points to be better than red line
 
@@ -428,7 +452,7 @@ df_corr_crop.loc[df_corr_crop["value"] < 0.5].sort_values(
 ).head(20)
 
 # %% [markdown]
-# ### Summary: Large pixel shifts
+# ### Summary: Large pixel shifts - ORIGINAL NCC ALIGNMENT METHOD
 
 # %%
 # Print huge pixel shifts
@@ -437,3 +461,184 @@ print(
 )
 
 df_shift.loc[df_shift["value"] > 100].sort_values(by="value", ascending=False).head(20)
+
+# %% [markdown]
+# ## Pixel Shifts Analysis - MI ALIGNMENT METHOD
+#
+# ### Pixels shifted to align each cycle to Cycle01 (no axis limits)
+
+# %%
+if has_MI:
+    sns.catplot(
+        data=df_shift_MI,
+        x="value",
+        y="variable",
+        orient="h",
+        col="Metadata_Well",
+        row="Metadata_Plate",
+    )
+    plt.savefig(
+        Path(output_dir) / "alignment_shifts_no_limits_MI.png", dpi=150, bbox_inches="tight"
+    )
+    plt.show()
+
+# %% [markdown]
+# ### Pixels shifted to align each cycle to Cycle01 (x axis limited to a range)
+
+# %%
+if has_MI:
+    g = sns.catplot(
+        data=df_shift_MI,
+        x="value",
+        y="variable",
+        orient="h",
+        col="Metadata_Well",
+        row="Metadata_Plate",
+    )
+    g.set(xlim=(-200, 200))
+    plt.savefig(
+        Path(output_dir) / "alignment_shifts_xlim_MI.png", dpi=150, bbox_inches="tight"
+    )
+    plt.show()
+
+# %% [markdown]
+# ### Summary: Sites with large shifts
+
+# %%
+if has_MI:
+    value = shift_threshold
+    temp = (
+        df_shift_MI.loc[df_shift_MI["value"] > value]
+        .groupby(["Metadata_Plate", "Metadata_Well", "Metadata_Site"])
+        .count()
+        .reset_index()
+    )
+    for well in temp["Metadata_Well"].unique():
+        print(
+            f"{well} has {len(temp.loc[temp['Metadata_Well'] == well])} site with shift more than {value} (out of {imperwell})"
+        )
+
+# %% [markdown]
+# ### Spatial distribution of large shifts
+#
+# Plot size of shift by location, ignoring shifts >200
+
+# %%
+if has_MI and pos_df is not None:
+    temp = (
+        df_shift_MI.loc[df_shift_MI["value"] > value]
+        .groupby(["Metadata_Plate", "Metadata_Well", "Metadata_Site"])
+        .max()
+        .reset_index()
+        .merge(pos_df)
+    )
+    temp = temp.loc[temp["value"] < 200]
+
+    if len(temp) > 0:
+        g = sns.relplot(
+            data=temp,
+            x="x_loc",
+            y="y_loc",
+            hue="value",  # hue_norm=(0,200),
+            col="Metadata_Well",
+            col_wrap=3,
+            palette="viridis",
+            marker="s",
+            s=150,
+        )
+        print(g._legend_data)
+        plt.savefig(
+            Path(output_dir) / "alignment_shifts_spatial_MI.png",
+            dpi=150,
+            bbox_inches="tight",
+        )
+        plt.show()
+    else:
+        print(f"No sites with shifts >{value} and <200 pixels")
+else:
+    print("Skipping spatial plot - no geometry provided")
+
+# %% [markdown]
+# ## Correlation Analysis - MI ALIGNMENT METHOD
+#
+# ### DAPI correlations after alignment (all pairwise comparisons)
+#
+# Need all points to be better than red line
+
+# %%
+if has_MI:
+    g = sns.catplot(
+        data=df_corr_MI,
+        x="value",
+        y="variable",
+        orient="h",
+        col="Metadata_Well",
+        row="Metadata_Plate",
+    )
+    g.refline(x=corr_threshold, color="red")
+    g.set(xlim=(0, None))
+    plt.savefig(
+        Path(output_dir) / "alignment_correlations_all_MI.png", dpi=150, bbox_inches="tight"
+    )
+    plt.show()
+
+# %% [markdown]
+# ### DAPI correlations after alignment (only correlations to Cycle01) - MI ALIGNMENT METHOD
+#
+# Need all points to be better than red line
+
+# %%
+if has_MI:
+    g = sns.catplot(
+    data=df_corr_crop_MI,
+    x="value",
+    y="variable",
+    orient="h",
+    col="Metadata_Well",
+    row="Metadata_Plate",
+    )
+    g.refline(x=corr_threshold, color="red")
+    g.set(xlim=(0, None))
+    plt.savefig(
+        Path(output_dir) / "alignment_correlations_cycle01_MI.png",
+        dpi=150,
+        bbox_inches="tight",
+    )
+    plt.show()
+
+# %% [markdown]
+# ### Summary: Correlation statistics
+
+# %%
+if has_MI:
+    print("For correlations to Cycle01")
+    print(
+        f"{len(df_corr_crop_MI.groupby(['Metadata_Plate', 'Metadata_Well', 'Metadata_Site']))} total sites"
+    )
+    print(
+        f"{len(df_corr_crop_MI.loc[df_corr_crop_MI['value'] < 0.9])} sites with correlation <.9"
+    )
+    print(
+        f"{len(df_corr_crop_MI.loc[df_corr_crop_MI['value'] < 0.8])} sites with correlation <.8"
+    )
+    # Print Awful alignment scores after alignment
+    df_corr_crop_MI.sort_values(by="value").head(20)
+
+# %%
+# Print mediocre alignment score after alignment
+if has_MI:
+    df_corr_crop_MI.loc[df_corr_crop_MI["value"] < 0.5].sort_values(
+        by="value", ascending=False
+    ).head(20)
+
+# %% [markdown]
+# ### Summary: Large pixel shifts - ORIGINAL NCC ALIGNMENT METHOD
+
+# %%
+# Print huge pixel shifts
+if has_MI:
+    print(
+        f"{len(df_shift_MI.loc[df_shift_MI['value'] > 100])} images shifted with huge pixel shifts"
+    )
+
+    df_shift_MI.loc[df_shift_MI["value"] > 100].sort_values(by="value", ascending=False).head(20)

--- a/bin/qc_barcode_align.py
+++ b/bin/qc_barcode_align.py
@@ -136,41 +136,42 @@ cache_file = Path(output_dir) / "cached_alignment_data.parquet"
 # Detect channel naming convention (DNA vs DAPI) by checking first available CSV
 channel_name = "DAPI"  # default
 folderlist = os.listdir(csvfolder)
-for folder in folderlist:
-    test_file = os.path.join(csvfolder, folder, "BarcodingApplication_Image.csv")
-    if os.path.isfile(test_file):
-        # Read just the header to check column names
-        test_df = pd.read_csv(test_file, nrows=0)
-        if "Align_Xshift_Cycle02_DNA" in test_df.columns:
-            channel_name = "DNA"
-            print("Detected channel naming convention: DNA")
-            break
-        elif "Align_Xshift_Cycle02_DAPI" in test_df.columns:
-            channel_name = "DAPI"
-            print("Detected channel naming convention: DAPI")
-            break
+test_file = os.path.join(csvfolder, folderlist[0], "BarcodingApplication_Image.csv")
+if os.path.isfile(test_file):
+    # Read just the header to check column names
+    test_df = pd.read_csv(test_file, nrows=0)
+    if "Align_Xshift_Cycle02_DNA" in test_df.columns:
+        channel_name = "DNA"
+        print("Detected channel naming convention: DNA")
+    elif "Align_Xshift_Cycle02_DAPI" in test_df.columns:
+        channel_name = "DAPI"
+        print("Detected channel naming convention: DAPI")
+    else:
+        print(f"Could not detect channel naming convention, defaulting to {channel_name}")
+    
+    orig_cols = [x for x in test_df.columns if "Correlation_Correlation" in x and "Orig" in x]
+    MI_cols = [x for x in test_df.columns if "MI" in x and channel_name in x]
+    print (f"Detected {len(MI_cols)} MI columns for channel {channel_name}")
+    debris_cols = [x for x in test_df.columns if "Count_Debris" in x]
+    print (f"Detected {len(debris_cols)} debris columns")
 
 # Build column lists using detected channel name
 shift_list = []
-shift_list_MI = []
 corr_list = []
-corr_list_MI = []
 for cycle in range(1, numcycles + 1):
     if cycle != 1:
         shift_list.append(f"Align_Xshift_Cycle{cycle:02d}_{channel_name}")
         shift_list.append(f"Align_Yshift_Cycle{cycle:02d}_{channel_name}")
-        shift_list_MI.append(f"Align_Xshift_Cycle{cycle:02d}_{channel_name}_MI")
-        shift_list_MI.append(f"Align_Yshift_Cycle{cycle:02d}_{channel_name}_MI")
     for cycle2 in range(cycle + 1, numcycles + 1):
         corr_list.append(
             f"Correlation_Correlation_Cycle{cycle:02d}_{channel_name}_Cycle{cycle2:02d}_{channel_name}"
         )
-        corr_list_MI.append(
-            f"Correlation_Correlation_Cycle{cycle:02d}_{channel_name}_Cycle{cycle2:02d}_{channel_name}_MI"
-        )
+shift_list_MI = [x for x in MI_cols if "Align_Xshift_Cycle" in x or "Align_Yshift_Cycle" in x]
+corr_list_MI = [x for x in MI_cols if "Correlation_Correlation_Cycle" in x]
+
 id_list = ["Metadata_Well", "Metadata_Plate", "Metadata_Site"]
-column_list_with_MI = id_list + shift_list + corr_list + shift_list_MI + corr_list_MI
-column_list_no_MI = id_list + shift_list + corr_list
+column_list_with_MI = id_list + shift_list + corr_list + shift_list_MI + corr_list_MI + debris_cols + orig_cols
+column_list_no_MI = id_list + shift_list + corr_list + debris_cols + orig_cols
 
 # Load data with caching support
 if use_cache and cache_file.exists():
@@ -190,14 +191,6 @@ else:
     print(f"Caching data to: {cache_file}")
     df_image.to_parquet(cache_file, compression="gzip", index=False)
     print("Cache saved")
-
-# Check if MI alignment was used
-has_MI = False
-has_debris = False
-if any(col in df_image.columns for col in shift_list_MI):
-    has_MI = True
-if any([x for x in df_image.columns if 'Debris' in x]):
-    has_debris = True
 
 # Detect site numbering convention (0-based or 1-based)
 min_site = df_image["Metadata_Site"].min()
@@ -268,6 +261,12 @@ else:
 if pos_df is not None:
     print(f"Position mapping created for {len(pos_df)} sites (starting at site {min_site})")
 
+# %%
+if (df_image[orig_cols] > 0.95).any().any():
+    corr = (df_image[orig_cols] > 0.95).any()
+    print("Some input images are very highly correlated. Check the following for accidental duplication:")
+    print(corr[corr].index.tolist())
+
 # %% [markdown]
 # ## Prepare Data for Analysis
 
@@ -278,7 +277,7 @@ df_corr = df_image[corr_list + id_list]
 df_corr = pd.melt(df_corr, id_vars=id_list)
 df_corr_crop = df_image[[x for x in corr_list if "Correlation_Cycle01" in x] + id_list]
 df_corr_crop = pd.melt(df_corr_crop, id_vars=id_list)
-if has_MI:
+if MI_cols:
     df_shift_MI = df_image[shift_list_MI + id_list]
     df_shift_MI = pd.melt(df_shift_MI, id_vars=id_list)
     df_corr_MI = df_image[corr_list_MI + id_list]
@@ -303,7 +302,7 @@ sns.catplot(
     y="variable",
     orient="h",
     col="Metadata_Well",
-    row="Metadata_Plate",
+    col_wrap=4,
 )
 plt.savefig(
     Path(output_dir) / "alignment_shifts_no_limits.png", dpi=150, bbox_inches="tight"
@@ -320,7 +319,7 @@ g = sns.catplot(
     y="variable",
     orient="h",
     col="Metadata_Well",
-    row="Metadata_Plate",
+    col_wrap=4,
 )
 g.set(xlim=(-200, 200))
 plt.savefig(
@@ -398,7 +397,7 @@ g = sns.catplot(
     y="variable",
     orient="h",
     col="Metadata_Well",
-    row="Metadata_Plate",
+    col_wrap=4,
 )
 g.refline(x=corr_threshold, color="red")
 g.set(xlim=(0, None))
@@ -419,7 +418,7 @@ g = sns.catplot(
     y="variable",
     orient="h",
     col="Metadata_Well",
-    row="Metadata_Plate",
+    col_wrap=4,
 )
 g.refline(x=corr_threshold, color="red")
 g.set(xlim=(0, None))
@@ -470,14 +469,14 @@ df_shift.loc[df_shift["value"] > 100].sort_values(by="value", ascending=False).h
 # ### Pixels shifted to align each cycle to Cycle01 (no axis limits)
 
 # %%
-if has_MI:
+if MI_cols:
     sns.catplot(
         data=df_shift_MI,
         x="value",
         y="variable",
         orient="h",
         col="Metadata_Well",
-        row="Metadata_Plate",
+        col_wrap=4,
     )
     plt.savefig(
         Path(output_dir) / "alignment_shifts_no_limits_MI.png", dpi=150, bbox_inches="tight"
@@ -488,14 +487,14 @@ if has_MI:
 # ### Pixels shifted to align each cycle to Cycle01 (x axis limited to a range)
 
 # %%
-if has_MI:
+if MI_cols:
     g = sns.catplot(
         data=df_shift_MI,
         x="value",
         y="variable",
         orient="h",
         col="Metadata_Well",
-        row="Metadata_Plate",
+        col_wrap=4,
     )
     g.set(xlim=(-200, 200))
     plt.savefig(
@@ -507,7 +506,7 @@ if has_MI:
 # ### Summary: Sites with large shifts
 
 # %%
-if has_MI:
+if MI_cols:
     value = shift_threshold
     temp = (
         df_shift_MI.loc[df_shift_MI["value"] > value]
@@ -526,7 +525,7 @@ if has_MI:
 # Plot size of shift by location, ignoring shifts >200
 
 # %%
-if has_MI and pos_df is not None:
+if MI_cols and pos_df is not None:
     temp = (
         df_shift_MI.loc[df_shift_MI["value"] > value]
         .groupby(["Metadata_Plate", "Metadata_Well", "Metadata_Site"])
@@ -568,14 +567,14 @@ else:
 # Need all points to be better than red line
 
 # %%
-if has_MI:
+if MI_cols:
     g = sns.catplot(
         data=df_corr_MI,
         x="value",
         y="variable",
         orient="h",
         col="Metadata_Well",
-        row="Metadata_Plate",
+        col_wrap=4,
     )
     g.refline(x=corr_threshold, color="red")
     g.set(xlim=(0, None))
@@ -590,14 +589,14 @@ if has_MI:
 # Need all points to be better than red line
 
 # %%
-if has_MI:
+if MI_cols:
     g = sns.catplot(
     data=df_corr_crop_MI,
     x="value",
     y="variable",
     orient="h",
     col="Metadata_Well",
-    row="Metadata_Plate",
+    col_wrap=4,
     )
     g.refline(x=corr_threshold, color="red")
     g.set(xlim=(0, None))
@@ -612,7 +611,7 @@ if has_MI:
 # ### Summary: Correlation statistics
 
 # %%
-if has_MI:
+if MI_cols:
     print("For correlations to Cycle01")
     print(
         f"{len(df_corr_crop_MI.groupby(['Metadata_Plate', 'Metadata_Well', 'Metadata_Site']))} total sites"
@@ -628,17 +627,17 @@ if has_MI:
 
 # %%
 # Print mediocre alignment score after alignment
-if has_MI:
+if MI_cols:
     df_corr_crop_MI.loc[df_corr_crop_MI["value"] < 0.5].sort_values(
         by="value", ascending=False
     ).head(20)
 
 # %% [markdown]
-# ### Summary: Large pixel shifts - ORIGINAL NCC ALIGNMENT METHOD
+# ### Summary: Large pixel shifts - MI ALIGNMENT METHOD
 
 # %%
 # Print huge pixel shifts
-if has_MI:
+if MI_cols:
     print(
         f"{len(df_shift_MI.loc[df_shift_MI['value'] > 100])} images shifted with huge pixel shifts"
     )

--- a/bin/qc_barcode_preprocess.py
+++ b/bin/qc_barcode_preprocess.py
@@ -87,14 +87,18 @@ bc_df = pd.read_csv(barcode_library_path)
 # Normalize gene column name to 'Gene'
 if "gene_symbol" in bc_df.columns:
     bc_df = bc_df.rename(columns={"gene_symbol": "Gene"})
+elif "target_symbol" in bc_df.columns:
+    bc_df = bc_df.rename(columns={"target_symbol": "Gene"})
 elif "Gene" not in bc_df.columns:
-    raise ValueError("Barcode library must contain 'Gene' or 'gene_symbol' column")
+    raise ValueError("Barcode library must contain 'Gene', 'gene_symbol', or 'target_symbol' column")
 
 # Normalize barcode column name to 'Barcode'
 if "sgRNA" in bc_df.columns:
     bc_df = bc_df.rename(columns={"sgRNA": "Barcode"})
+elif "barcode_to_call" in bc_df.columns:
+    bc_df = bc_df.rename(columns={"barcode_to_call": "Barcode"})
 elif "Barcode" not in bc_df.columns:
-    raise ValueError("Barcode library must contain 'Barcode' or 'sgRNA' column")
+    raise ValueError("Barcode library must contain 'Barcode', 'sgRNA', or 'barcode_to_call' column")
 
 gene_col = "Gene"
 barcode_col = "Barcode"
@@ -253,7 +257,6 @@ column_list = [
     "Metadata_Plate",
     "Metadata_Site",
     "Metadata_Well",
-    "Metadata_Well_Value",
     "Barcode_BarcodeCalled",
     "Barcode_MatchedTo_Barcode",
     "Barcode_MatchedTo_GeneCode",
@@ -290,11 +293,11 @@ df_foci.head()
 
 # %%
 # useful dataframe manipulations
-df_foci.sort_values(by=["Metadata_Well_Value", "Metadata_Site"], inplace=True)
+df_foci.sort_values(by=["Metadata_Well", "Metadata_Site"], inplace=True)
 df_foci["well-site"] = (
     df_foci["Metadata_Well"] + "-" + df_foci["Metadata_Site"].astype(str)
 )
-df_foci_well_groups = df_foci.groupby("Metadata_Well_Value")
+df_foci_well_groups = df_foci.groupby("Metadata_Well")
 
 print(
     sum(df_foci["Barcode_MatchedTo_Score"] == 1)
@@ -313,7 +316,7 @@ plt.show()
 
 # %%
 sns_displot = sns.displot(
-    df_foci, x="Barcode_MatchedTo_Score", col="Metadata_Well_Value", col_wrap=3
+    df_foci, x="Barcode_MatchedTo_Score", col="Metadata_Well", col_wrap=3
 )
 plt.tight_layout()
 plt.savefig(
@@ -335,6 +338,16 @@ print(
         ]
     ).mean()
 )
+
+print("% Reads with >4 repeat X calls")
+print(100*len([x for x in readlist if 'XXXXX' in x])/len(readlist))
+
+print("% Reads that are all unassigned (X) calls")
+print(100*len([x for x in readlist if set(x)=={'X'}])/len(readlist))
+
+print("% Reads with unassigned (X) nucleotide calls")
+print(100*len([x for x in readlist if 'X' in x])/len(readlist))
+
 
 # %%
 # Pos df
@@ -471,6 +484,13 @@ for cycle in range(1, numcycles + 1):
             "Frequency": float(BarcodeCat.count("T")) / float(len(BarcodeCat)),
         }
     )
+    dflist.append(
+        {
+            "Cycle": int(cycle),
+            "Nucleotide": "X",
+            "Frequency": float(BarcodeCat.count("X")) / float(len(BarcodeCat)),
+        }
+    )
 df_parsed = pd.DataFrame(dflist)
 g = sns.lineplot(x="Cycle", y="Frequency", hue="Nucleotide", data=df_parsed)
 g.set_ylim([0.1, 0.5])
@@ -481,6 +501,18 @@ plt.title("Observed Nucleotide Frequency by Cycle")
 plt.tight_layout()
 plt.savefig(
     Path(output_dir) / "observed_nucleotide_frequency.png", dpi=150, bbox_inches="tight"
+)
+plt.show()
+
+# %%
+g = sns.lineplot(x="Cycle", y="Frequency", hue="Nucleotide", data=df_parsed)
+handles, labels = g.get_legend_handles_labels()
+g.legend(handles=handles[0:], labels=labels[0:])
+g.set_xticks(list(range(1, numcycles + 1)))
+plt.title("Observed Nucleotide Frequency by Cycle")
+plt.tight_layout()
+plt.savefig(
+    Path(output_dir) / "observed_nucleotide_frequency_noYlim.png", dpi=150, bbox_inches="tight"
 )
 plt.show()
 

--- a/conf/LOCAL_TEST.config
+++ b/conf/LOCAL_TEST.config
@@ -1,0 +1,110 @@
+params {
+    config_profile_name         = 'LOCAL_TEST'
+    config_profile_description  = 'two wells'
+
+    // Input data
+    input                       = "/Users/eweisbar/Desktop/LOCAL_RUN/BR00149745_pSMC_E03F03_samplesheet.csv"
+    outdir = "/Users/eweisbar/Desktop/LOCAL_RUN/out"
+    barcodes                    = "/Users/eweisbar/Documents/projects/POtC/potc_CRISPRi_pilot_library_design.csv"
+    fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.env_master.py"
+    cycle_metadata_name         = "Cycle"
+    callbarcodes_plugin = "/Users/eweisbar/Desktop/github/CellProfiler-plugins/active_plugins/callbarcodes.py"
+
+    painting_illumcalc_cppipe   = "/Users/eweisbar/Desktop/2026_03_20_PotC/1_CP_Illum_MultiCycle.cppipe"
+    painting_illumapply_cppipe  = "/Users/eweisbar/Desktop/2026_03_20_PotC/2_CP_Apply_Illum_MultiCycle.cppipe"
+    painting_segcheck_cppipe    = "/Users/eweisbar/Desktop/2026_03_20_PotC/3_CP_SegmentationCheck_BR00149745_pSMC.cppipe"
+    barcoding_illumcalc_cppipe  = "/Users/eweisbar/Desktop/2026_03_20_PotC/5_BC_Illum.cppipe"
+    barcoding_illumapply_cppipe = "/Users/eweisbar/Desktop/2026_03_20_PotC/6_BC_ApplyIllum_Masks.cppipe"
+    barcoding_preprocess_cppipe = "/Users/eweisbar/Desktop/2026_03_20_PotC/7_BC_Preprocess_BR00149745_pSMC_Mask.cppipe"
+    combinedanalysis_cppipe     = "/Users/eweisbar/Desktop/2026_03_20_PotC/9_Analysis.cppipe"
+
+    range_skip = 4
+    painting_quarter_if_round = false
+    barcoding_quarter_if_round = false
+    painting_imperwell = 80
+    barcoding_imperwell = 21
+    painting_rows = 10
+    barcoding_columns = 5
+    painting_columns = 10
+    barcoding_columns = 5
+    tileperside = 5
+    final_tile_size = 2000
+    phenix = true
+    barcoding_illumapply_grouping = "site"
+    barcoding_channame = "DAPI"
+}
+
+process {
+    withName: 'POOLED_CELLPAINTING:BARCODING:CELLPROFILER_ILLUMAPPLY_BARCODING' {
+        cpus   = { 6 * task.attempt }
+        memory = { 6.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:CELLPROFILER_ILLUMCALC' {
+        cpus   = { 2 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:CELLPROFILER_PREPROCESS' {
+        cpus   = { 2 * task.attempt }
+        memory = { 7.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:FIJI_STITCHCROP' {
+        cpus   = { 1 * task.attempt }
+        memory = { 28.GB * task.attempt }
+        containerOptions = '--platform linux/amd64'
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:QC_BARCODEALIGN' {
+        cpus   = { 2 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:QC_MONTAGEILLUM_BARCODING' {
+        cpus   = { 2 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:QC_MONTAGE_STITCHCROP_BARCODING' {
+        cpus   = { 2 * task.attempt }
+        memory = { 6.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:BARCODING:QC_PREPROCESS' {
+        cpus   = { 1 * task.attempt }
+        memory = { 2.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:CELLPROFILER_ILLUMAPPLY_PAINTING' {
+        cpus   = { 4 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:CELLPROFILER_ILLUMCALC' {
+        cpus   = { 2 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:CELLPROFILER_SEGCHECK' {
+        cpus   = { 2 * task.attempt }
+        memory = { 2.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:FIJI_STITCHCROP' {
+        cpus   = { 2 * task.attempt }
+        memory = { 28.GB * task.attempt }
+        containerOptions = '--platform linux/amd64'
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:QC_MONTAGEILLUM_PAINTING' {
+        cpus   = { 2 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:QC_MONTAGE_SEGCHECK' {
+        cpus   = { 1 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPAINTING:QC_MONTAGE_STITCHCROP_PAINTING' {
+        cpus   = { 2 * task.attempt }
+        memory = { 3.GB * task.attempt }
+    }
+    withName: 'POOLED_CELLPAINTING:CELLPROFILER_COMBINEDANALYSIS' {
+        cpus   = { 3 * task.attempt }
+        memory = { 30.GB }
+    }
+    withName: 'POOLED_CELLPAINTING:MULTIQC' {
+        cpus   = { 4 * task.attempt }
+        memory = { 1.GB * task.attempt }
+    }
+    errorStrategy = 'retry'
+    maxRetries    = 0
+}

--- a/conf/base.config
+++ b/conf/base.config
@@ -9,56 +9,59 @@
 */
 
 process {
+    // 2147483647 is from spot fleet instance being pulled so it is handled differently
+    cpus          = { task.exitStatus == 2147483647 ? 1 : 1 * task.attempt }
+    memory        = { task.exitStatus == 2147483647 ? 6.GB : 6.GB * task.attempt }
+    time          = { task.exitStatus == 2147483647 ? 4.h : 4.h * task.attempt }
 
-    cpus          = { 1 * task.attempt }
-    memory        = { 6.GB * task.attempt }
-    time          = { 4.h * task.attempt }
-
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 2147483647) ? 'retry' : 'finish' }
-    maxRetries    = 1
+    errorStrategy = {
+        if (task.exitStatus == 2147483647) {
+            task.attempt <= 8 ? 'retry' : 'finish'
+        } else if (task.exitStatus in ((130..145) + 104 + 175)) {
+            task.attempt <= 2 ? 'retry' : 'finish'
+        } else {
+            'finish'
+        }
+    }
+    maxRetries    = 8
     maxErrors     = '-1'
 
     // Process-specific resource requirements
-    // NOTE - Please try and reuse the labels below as much as possible.
-    //        These labels are used and recognised by default in DSL2 files hosted on nf-core/modules.
-    //        If possible, it would be nice to keep the same label naming convention when
-    //        adding in your local modules too.
-    // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel: process_single {
         cpus   = { 1 }
-        memory = { 6.GB * task.attempt }
-        time   = { 4.h * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 6.GB : 6.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 4.h : 4.h * task.attempt }
     }
     withLabel: qc {
         cpus   = { 1 }
-        memory = { 6.GB * task.attempt }
-        time   = { 4.h * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 6.GB : 6.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 4.h : 4.h * task.attempt }
     }
     withLabel: cellprofiler_basic {
-        cpus   = { 1 * task.attempt }
-        memory = { 2.GB * task.attempt }
-        time   = { 8.h * task.attempt }
+        cpus   = { task.exitStatus == 2147483647 ? 1 : 1 * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 2.GB : 2.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 8.h : 8.h * task.attempt }
     }
     withLabel: cellprofiler_medium {
-        cpus   = { 4 * task.attempt }
-        memory = { 3.GB * task.attempt }
-        time   = { 8.h * task.attempt }
+        cpus   = { task.exitStatus == 2147483647 ? 4 : 4 * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 3.GB : 3.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 8.h : 8.h * task.attempt }
     }
     withLabel: cellprofiler_large {
-        cpus   = { 4 * task.attempt }
-        memory = { 12.GB * task.attempt }
-        time   = { 8.h * task.attempt }
+        cpus   = { task.exitStatus == 2147483647 ? 4 : 4 * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 12.GB : 12.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 8.h : 8.h * task.attempt }
     }
     withLabel: fiji {
-        cpus   = { 6 * task.attempt }
-        memory = { 36.GB * task.attempt }
-        time   = { 8.h * task.attempt }
+        cpus   = { task.exitStatus == 2147483647 ? 6 : 6 * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 36.GB : 36.GB * task.attempt }
+        time   = { task.exitStatus == 2147483647 ? 8.h : 8.h * task.attempt }
     }
     withLabel: process_long {
-        time = { 20.h * task.attempt }
+        time = { task.exitStatus == 2147483647 ? 20.h : 20.h * task.attempt }
     }
     withLabel: process_high_memory {
-        memory = { 200.GB * task.attempt }
+        memory = { task.exitStatus == 2147483647 ? 200.GB : 200.GB * task.attempt }
     }
     withLabel: error_ignore {
         errorStrategy = 'ignore'

--- a/conf/base.config
+++ b/conf/base.config
@@ -44,6 +44,11 @@ process {
         memory = { 3.GB * task.attempt }
         time   = { 8.h * task.attempt }
     }
+    withLabel: cellprofiler_large {
+        cpus   = { 4 * task.attempt }
+        memory = { 12.GB * task.attempt }
+        time   = { 8.h * task.attempt }
+    }
     withLabel: fiji {
         cpus   = { 6 * task.attempt }
         memory = { 36.GB * task.attempt }

--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
     memory        = { 6.GB * task.attempt }
     time          = { 4.h * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 2147483647) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -164,7 +164,7 @@ process {
             ],
             [
                 path: { "${params.outdir}/images/${meta.batch}/images_corrected_cropped/${meta.arm}/${meta.plate}/${meta.plate}-${meta.well}" },
-                pattern: "cropped_images/**/*.tiff",
+                pattern: "cropped_images/**.tiff",
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.replaceAll('cropped_images/', '') },
             ],

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -164,7 +164,7 @@ process {
             ],
             [
                 path: { "${params.outdir}/images/${meta.batch}/images_corrected_cropped/${meta.arm}/${meta.plate}/${meta.plate}-${meta.well}" },
-                pattern: "cropped_images/*.tiff",
+                pattern: "cropped_images/**/*.tiff",
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.replaceAll('cropped_images/', '') },
             ],

--- a/conf/test.config
+++ b/conf/test.config
@@ -63,6 +63,7 @@ params {
     barcoding_overlap_pct       = 10
     barcoding_scalingstring     = 2
     barcoding_imperwell         = 4
+    barcoding_channame = "DNA"
     // Used if round - no default value was set in original script
     barcoding_rows              = 2
     // Used if square

--- a/conf/test.config
+++ b/conf/test.config
@@ -49,7 +49,7 @@ params {
     painting_quarter_if_round   = true
     painting_overlap_pct        = 10
     painting_scalingstring      = 2
-    painting_imperwell          = "unused"
+    painting_imperwell          = 4
     // Used if round - no default value was set in original script
     painting_rows               = 2
     // Used if square
@@ -62,7 +62,7 @@ params {
     barcoding_quarter_if_round  = true
     barcoding_overlap_pct       = 10
     barcoding_scalingstring     = 2
-    barcoding_imperwell         = "unused"
+    barcoding_imperwell         = 4
     // Used if round - no default value was set in original script
     barcoding_rows              = 2
     // Used if square

--- a/conf/test_cpg0032.config
+++ b/conf/test_cpg0032.config
@@ -62,7 +62,7 @@ params {
     painting_quarter_if_round   = true
     painting_overlap_pct        = 10
     painting_scalingstring      = 1.99
-    painting_imperwell          = "256"
+    painting_imperwell          = 256
     painting_stitchorder        = "Grid: snake by rows"
     painting_channame           = "DNA"
 
@@ -71,7 +71,7 @@ params {
     barcoding_quarter_if_round  = true
     barcoding_overlap_pct       = 10
     barcoding_scalingstring     = 1
-    barcoding_imperwell         = "56"
+    barcoding_imperwell         = 56
     barcoding_stitchorder       = "Grid: snake by rows"
     barcoding_channame          = "DAPI"
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -54,7 +54,7 @@ params {
     painting_quarter_if_round   = true
     painting_overlap_pct        = 10
     painting_scalingstring      = 1
-    painting_imperwell          = "1025"
+    painting_imperwell          = 1025
     // Used if round - no default value was set in original script
     painting_rows               = 2
     // Used if square
@@ -67,7 +67,7 @@ params {
     barcoding_quarter_if_round  = true
     barcoding_overlap_pct       = 10
     barcoding_scalingstring     = 1
-    barcoding_imperwell         = "1025"
+    barcoding_imperwell         = 1025
     // Used if round - no default value was set in original script
     barcoding_rows              = 2
     // Used if square

--- a/modules/local/cellprofiler/combinedanalysis/main.nf
+++ b/modules/local/cellprofiler/combinedanalysis/main.nf
@@ -13,7 +13,7 @@ process CELLPROFILER_COMBINEDANALYSIS {
     path plugins, stageAs: "plugins/"
 
     output:
-    tuple val(meta), path("*.png"), emit: overlay_images
+    tuple val(meta), path("*.png"), emit: overlay_images, optional: true
     tuple val(meta), path("*.csv"), emit: csv_stats
     tuple val(meta), path("segmentation_masks/*.tiff"), emit: segmentation_masks, optional: true
     path "load_data.csv", emit: load_data_csv

--- a/modules/local/cellprofiler/combinedanalysis/main.nf
+++ b/modules/local/cellprofiler/combinedanalysis/main.nf
@@ -9,7 +9,7 @@ process CELLPROFILER_COMBINEDANALYSIS {
     input:
     tuple val(meta), path(cropped_images, stageAs: "images/"), val(image_metas)
     path combinedanalysis_cppipe
-    path barcodes, stageAs: "images/Barcodes.csv"
+    path barcodes    // stage to root to prevent collision with image file staging
     path plugins, stageAs: "plugins/"
 
     output:
@@ -37,6 +37,9 @@ process CELLPROFILER_COMBINEDANALYSIS {
 
     # Create metadata JSON file from base64 (reduces log verbosity)
     echo '${metadata_base64}' | base64 -d > metadata.json
+
+    # Stage barcodes into images/ directory (avoids Nextflow 26 + Fusion stageAs conflict)
+    ln -sf ../\${barcodes} ./images/Barcodes.csv
 
     # Generate load_data.csv using the unified script with 'combined' pipeline type
     generate_load_data_csv.py \\

--- a/modules/local/cellprofiler/combinedanalysis/main.nf
+++ b/modules/local/cellprofiler/combinedanalysis/main.nf
@@ -39,7 +39,7 @@ process CELLPROFILER_COMBINEDANALYSIS {
     echo '${metadata_base64}' | base64 -d > metadata.json
 
     # Stage barcodes into images/ directory (avoids Nextflow 26 + Fusion stageAs conflict)
-    ln -sf ../\${barcodes} ./images/Barcodes.csv
+    cp -L ${barcodes} ./images/${barcodes}
 
     # Generate load_data.csv using the unified script with 'combined' pipeline type
     generate_load_data_csv.py \\

--- a/modules/local/cellprofiler/combinedanalysis/main.nf
+++ b/modules/local/cellprofiler/combinedanalysis/main.nf
@@ -1,6 +1,6 @@
 process CELLPROFILER_COMBINEDANALYSIS {
     tag "${meta.id}"
-    label 'cellprofiler_medium'
+    label 'cellprofiler_large'
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/cellprofiler:4.2.8--7c1bd3a82764de92'

--- a/modules/local/cellprofiler/combinedanalysis/tests/main.nf.test
+++ b/modules/local/cellprofiler/combinedanalysis/tests/main.nf.test
@@ -48,6 +48,7 @@ nextflow_process {
                     [
                         plate: 'Plate1',
                         batch: 'Batch1',
+                        cycles: [1, 2, 3],
                         image_metadata: [
                             // Painting images
                             [well:'A1', site:1, filename:'Plate_Plate1_Well_A1_Site_1_CorrCHN2.tiff', type:'cellpainting', channel:'CHN2'],
@@ -152,6 +153,7 @@ nextflow_process {
                     [
                         plate: 'Plate1',
                         batch: 'Batch1',
+                        cycles: [1, 2, 3],
                         image_metadata: [
                             // Painting images
                             [well:'A1', site:1, filename:'Plate_Plate1_Well_A1_Site_1_CorrCHN2.tiff', type:'cellpainting', channel:'CHN2'],

--- a/modules/local/cellprofiler/combinedanalysis/tests/main.nf.test.snap
+++ b/modules/local/cellprofiler/combinedanalysis/tests/main.nf.test.snap
@@ -130,11 +130,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-11T13:23:45.6324904",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-11-03T12:32:45.620408"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "cellprofiler - combinedanalysis - cropped_images": {
         "content": [
@@ -172,10 +172,10 @@
                 "versions.yml:md5,795803aa173c77404af3cf020ec3f8d2"
             ]
         ],
+        "timestamp": "2026-06-11T13:23:35.504790852",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-11-10T20:34:10.949948283"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/modules/local/cellprofiler/preprocess/main.nf
+++ b/modules/local/cellprofiler/preprocess/main.nf
@@ -9,7 +9,7 @@ process CELLPROFILER_PREPROCESS {
     input:
     tuple val(meta), path(aligned_images, stageAs: "images/"), val(image_metas)
     path preprocess_cppipe
-    path barcodes, stageAs: "images/Barcodes.csv"
+    path barcodes    // stage to root to prevent collision with image file staging
     path plugins, stageAs: "plugins/"
 
     output:
@@ -31,6 +31,9 @@ process CELLPROFILER_PREPROCESS {
     """
     # Create metadata JSON file from base64 (reduces log verbosity)
     echo '${metadata_base64}' | base64 -d > metadata.json
+
+    # Stage barcodes into images/ directory (avoids Nextflow 26 + Fusion stageAs conflict)
+    ln -sf ../\${barcodes} ./images/Barcodes.csv
 
     # Generate load_data.csv
     generate_load_data_csv.py \\

--- a/modules/local/cellprofiler/preprocess/main.nf
+++ b/modules/local/cellprofiler/preprocess/main.nf
@@ -33,7 +33,7 @@ process CELLPROFILER_PREPROCESS {
     echo '${metadata_base64}' | base64 -d > metadata.json
 
     # Stage barcodes into images/ directory (avoids Nextflow 26 + Fusion stageAs conflict)
-    ln -sf ../\${barcodes} ./images/Barcodes.csv
+    cp -L ${barcodes} ./images/${barcodes}
 
     # Generate load_data.csv
     generate_load_data_csv.py \\

--- a/modules/local/fiji/stitchcrop/main.nf
+++ b/modules/local/fiji/stitchcrop/main.nf
@@ -27,7 +27,7 @@ process FIJI_STITCHCROP {
     output:
     tuple val(meta), path("stitched_images/*.tiff"), emit: stitched_images
     tuple val(meta), path("stitched_images/TileConfiguration.txt"), emit: tile_config
-    tuple val(meta), path("cropped_images/**/*.tiff"), emit: cropped_images
+    tuple val(meta), path("cropped_images/**.tiff"), emit: cropped_images
     tuple val(meta), path("downsampled_images/*.tiff"), emit: downsampled_images
     path ("versions.yml"), emit: versions
 

--- a/modules/local/fiji/stitchcrop/main.nf
+++ b/modules/local/fiji/stitchcrop/main.nf
@@ -68,6 +68,7 @@ process FIJI_STITCHCROP {
     export COMPRESS="${compress}"
     export CHANNAME="${channame}"
     export PHENIX="${phenix}"
+    export FIRST_SITE_INDEX="${first_site_index}"
 
     # Run Fiji in headless mode
     /opt/fiji/Fiji.app/ImageJ-linux64 \\

--- a/modules/local/fiji/stitchcrop/main.nf
+++ b/modules/local/fiji/stitchcrop/main.nf
@@ -20,13 +20,14 @@ process FIJI_STITCHCROP {
     val xoffset_tiles
     val yoffset_tiles
     val compress
+    val phenix
     val channame
     val should_run
 
     output:
     tuple val(meta), path("stitched_images/*.tiff"), emit: stitched_images
     tuple val(meta), path("stitched_images/TileConfiguration.txt"), emit: tile_config
-    tuple val(meta), path("cropped_images/*.tiff"), emit: cropped_images
+    tuple val(meta), path("cropped_images/**/*.tiff"), emit: cropped_images
     tuple val(meta), path("downsampled_images/*.tiff"), emit: downsampled_images
     path ("versions.yml"), emit: versions
 
@@ -66,7 +67,7 @@ process FIJI_STITCHCROP {
     export YOFFSET_TILES="${yoffset_tiles}"
     export COMPRESS="${compress}"
     export CHANNAME="${channame}"
-    export FIRST_SITE_INDEX="${first_site_index}"
+    export PHENIX="${phenix}"
 
     # Run Fiji in headless mode
     /opt/fiji/Fiji.app/ImageJ-linux64 \\
@@ -94,16 +95,16 @@ process FIJI_STITCHCROP {
         # Barcoding arm - use Cycle format
         touch stitched_images/${prefix}_Stitched_Cycle01_DNA.tiff
         touch stitched_images/TileConfiguration.txt
-        touch cropped_images/${prefix}_Cycle01_DNA.tiff
-        touch cropped_images/${prefix}_Cycle01_A.tiff
-        touch cropped_images/${prefix}_Cycle02_A.tiff
+        touch cropped_images/DNA/${prefix}_Cycle01_DNA.tiff
+        touch cropped_images/A/${prefix}_Cycle01_A.tiff
+        touch cropped_images/A/${prefix}_Cycle02_A.tiff
         touch downsampled_images/${prefix}_Stitched_Cycle01_DNA.tiff
     else
         # Cell painting arm - use Corr format
         touch stitched_images/${prefix}_Stitched_CorrDNA.tiff
         touch stitched_images/TileConfiguration.txt
-        touch cropped_images/${prefix}_CorrDNA.tiff
-        touch cropped_images/${prefix}_CorrER.tiff
+        touch cropped_images/DNA/${prefix}_CorrDNA.tiff
+        touch cropped_images/ER/${prefix}_CorrER.tiff
         touch downsampled_images/${prefix}_Stitched_CorrDNA.tiff
     fi
 

--- a/modules/local/fiji/stitchcrop/main.nf
+++ b/modules/local/fiji/stitchcrop/main.nf
@@ -95,16 +95,16 @@ process FIJI_STITCHCROP {
         # Barcoding arm - use Cycle format
         touch stitched_images/${prefix}_Stitched_Cycle01_DNA.tiff
         touch stitched_images/TileConfiguration.txt
-        touch cropped_images/DNA/${prefix}_Cycle01_DNA.tiff
-        touch cropped_images/A/${prefix}_Cycle01_A.tiff
-        touch cropped_images/A/${prefix}_Cycle02_A.tiff
+        touch cropped_images/${prefix}_Cycle01_DNA.tiff
+        touch cropped_images/${prefix}_Cycle01_A.tiff
+        touch cropped_images/${prefix}_Cycle02_A.tiff
         touch downsampled_images/${prefix}_Stitched_Cycle01_DNA.tiff
     else
         # Cell painting arm - use Corr format
         touch stitched_images/${prefix}_Stitched_CorrDNA.tiff
         touch stitched_images/TileConfiguration.txt
-        touch cropped_images/DNA/${prefix}_CorrDNA.tiff
-        touch cropped_images/ER/${prefix}_CorrER.tiff
+        touch cropped_images/${prefix}_CorrDNA.tiff
+        touch cropped_images/${prefix}_CorrER.tiff
         touch downsampled_images/${prefix}_Stitched_CorrDNA.tiff
     fi
 

--- a/modules/local/fiji/stitchcrop/meta.yml
+++ b/modules/local/fiji/stitchcrop/meta.yml
@@ -115,7 +115,7 @@ output:
       - "*.tiff":
           type: file
           description: Cropped tile images extracted from stitched images for downstream analysis
-          pattern: "cropped_images/**/*.{tif,tiff}"
+          pattern: "cropped_images/**.{tif,tiff}"
           ontologies:
             - edam: http://edamontology.org/format_3547
   - downsampled_images:

--- a/modules/local/fiji/stitchcrop/meta.yml
+++ b/modules/local/fiji/stitchcrop/meta.yml
@@ -74,6 +74,9 @@ input:
   - compress:
       type: boolean
       description: Whether to compress output images
+  - phenix:
+      type: boolean
+      description: Whether the first site is centered in the well (Phenix acquisition pattern) or in the upper left corner (non-Phenix)
   - should_run:
       type: boolean
       description: Whether to run the stitching process
@@ -112,7 +115,7 @@ output:
       - "*.tiff":
           type: file
           description: Cropped tile images extracted from stitched images for downstream analysis
-          pattern: "cropped_images/*.{tif,tiff}"
+          pattern: "cropped_images/**/*.{tif,tiff}"
           ontologies:
             - edam: http://edamontology.org/format_3547
   - downsampled_images:

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test
@@ -48,6 +48,7 @@ nextflow_process {
                 input[14] = true                       // compress
                 input[15] = "DNA"                     // channame
                 input[16] = true                       // should_run
+                input[17] = false                      //phenix
                 """
             }
         }
@@ -124,6 +125,7 @@ nextflow_process {
                 input[14] = true                       // compress
                 input[15] = "DAPI"                    // channame
                 input[16] = true                       // should_run
+                input[17] = false                      //phenix
                 """
             }
         }
@@ -170,6 +172,7 @@ nextflow_process {
                 input[14] = true                       // compress
                 input[15] = "DNA"                     // channame
                 input[16] = true                       // should_run
+                input[17] = false                      //phenix
                 """
             }
         }

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test
@@ -37,7 +37,7 @@ nextflow_process {
                 input[3] = true                        // painting_quarter_if_round
                 input[4] = 10                          // painting_overlap_pct
                 input[5] = 2                           // painting_scalingstring
-                input[6] = "unused"                    // painting_imperwell
+                input[6] = 1                           // painting_imperwell
                 input[7] = 2                           // painting_rows
                 input[8] = 2                           // painting_columns
                 input[9] = "Grid: snake by rows"      // painting_stitchorder
@@ -113,7 +113,7 @@ nextflow_process {
                 input[3] = true                        // barcoding_quarter_if_round
                 input[4] = 10                          // barcoding_overlap_pct
                 input[5] = 2                           // barcoding_scalingstring
-                input[6] = "unused"                    // barcoding_imperwell
+                input[6] = 1                           // barcoding_imperwell
                 input[7] = 2                           // barcoding_rows
                 input[8] = 2                           // barcoding_columns
                 input[9] = "Grid: snake by rows"      // barcoding_stitchorder
@@ -159,7 +159,7 @@ nextflow_process {
                 input[3] = true                        // painting_quarter_if_round
                 input[4] = 10                          // painting_overlap_pct
                 input[5] = 2                           // painting_scalingstring
-                input[6] = "unused"                    // painting_imperwell
+                input[6] = 1                           // painting_imperwell
                 input[7] = 2                           // painting_rows
                 input[8] = 2                           // painting_columns
                 input[9] = "Grid: snake by rows"      // painting_stitchorder

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test
@@ -46,9 +46,9 @@ nextflow_process {
                 input[12] = 0                          // painting_xoffset_tiles
                 input[13] = 0                          // painting_yoffset_tiles
                 input[14] = true                       // compress
-                input[15] = "DNA"                     // channame
-                input[16] = true                       // should_run
-                input[17] = false                      //phenix
+                input[15] = false                      //phenix
+                input[16] = "DNA"                     // channame
+                input[17] = true                       // should_run
                 """
             }
         }
@@ -123,9 +123,9 @@ nextflow_process {
                 input[12] = 0                          // barcoding_xoffset_tiles
                 input[13] = 0                          // barcoding_yoffset_tiles
                 input[14] = true                       // compress
-                input[15] = "DAPI"                    // channame
-                input[16] = true                       // should_run
-                input[17] = false                      //phenix
+                input[15] = false                      //phenix                
+                input[16] = "DAPI"                    // channame
+                input[17] = true                       // should_run
                 """
             }
         }
@@ -170,9 +170,9 @@ nextflow_process {
                 input[12] = 0                          // painting_xoffset_tiles
                 input[13] = 0                          // painting_yoffset_tiles
                 input[14] = true                       // compress
-                input[15] = "DNA"                     // channame
-                input[16] = true                       // should_run
-                input[17] = false                      //phenix
+                input[15] = false                      //phenix
+                input[16] = "DNA"                     // channame
+                input[17] = true                       // should_run
                 """
             }
         }

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test
@@ -123,7 +123,7 @@ nextflow_process {
                 input[12] = 0                          // barcoding_xoffset_tiles
                 input[13] = 0                          // barcoding_yoffset_tiles
                 input[14] = true                       // compress
-                input[15] = false                      //phenix                
+                input[15] = false                      //phenix
                 input[16] = "DAPI"                    // channame
                 input[17] = true                       // should_run
                 """

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test.snap
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test.snap
@@ -1,4 +1,28 @@
 {
+    "fiji - stitchcrop - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "batch": "Batch1",
+                        "plate": "Plate1",
+                        "arm": "painting",
+                        "well": "A1",
+                        "id": "Batch1_Plate1_painting_A1"
+                    },
+                    "TileConfiguration.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                "versions.yml:md5,48fdc2d868518f7d0d672ab1488db410"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        },
+        "timestamp": "2026-06-11T18:32:00.000000000"
+    },
     "fiji - stitchcrop - painting - corrected_images": {
         "content": [
             [

--- a/modules/local/fiji/stitchcrop/tests/main.nf.test.snap
+++ b/modules/local/fiji/stitchcrop/tests/main.nf.test.snap
@@ -1,28 +1,4 @@
 {
-    "fiji - stitchcrop - stub": {
-        "content": [
-            [
-                [
-                    {
-                        "batch": "Batch1",
-                        "plate": "Plate1",
-                        "arm": "painting",
-                        "well": "A1",
-                        "id": "Batch1_Plate1_painting_A1"
-                    },
-                    "TileConfiguration.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                "versions.yml:md5,48fdc2d868518f7d0d672ab1488db410"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-11-18T01:41:55.53558124"
-    },
     "fiji - stitchcrop - painting - corrected_images": {
         "content": [
             [
@@ -41,10 +17,10 @@
                 "versions.yml:md5,05ad37a5e97798a96e40b06bcfb25949"
             ]
         ],
+        "timestamp": "2026-06-11T14:11:10.89526213",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-01T21:15:13.480352318"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -204,8 +204,8 @@ profiles {
     test_full {
         includeConfig 'conf/test_full.config'
     }
-    LOCAL_TEST {
-        includeConfig 'conf/LOCAL_TEST.config'
+    test_cpg0032 {
+        includeConfig 'conf/test_cpg0032.config'
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
     painting_quarter_if_round     = true
     painting_overlap_pct          = 10
     painting_scalingstring        = 1
-    painting_imperwell            = "unused"
+    painting_imperwell            = 80
     // Used if round - no default value was set in original script
     painting_rows                 = 2
     // Used if square
@@ -39,7 +39,7 @@ params {
     barcoding_quarter_if_round    = true
     barcoding_overlap_pct         = 10
     barcoding_scalingstring       = 1.99
-    barcoding_imperwell           = "unused"
+    barcoding_imperwell           = 20
     // Used if round - no default value was set in original script
     barcoding_rows                = 2
     // Used if square
@@ -48,11 +48,12 @@ params {
     barcoding_stitchorder         = "Grid: snake by rows"
     barcoding_xoffset_tiles       = 0
     barcoding_yoffset_tiles       = 0
-    barcoding_channame            = "DNA"
+    barcoding_channame            = "DAPI"
 
     // Stitching/Cropping parameters - Shared between painting and barcoding
     tileperside                   = 10
     final_tile_size               = 5500
+    phenix                        = false
 
     // Stitching/Cropping parameters - Troubleshooting (rarely modified)
     compress                      = true
@@ -203,8 +204,8 @@ profiles {
     test_full {
         includeConfig 'conf/test_full.config'
     }
-    test_cpg0032 {
-        includeConfig 'conf/test_cpg0032.config'
+    LOCAL_TEST {
+        includeConfig 'conf/LOCAL_TEST.config'
     }
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -142,8 +142,8 @@
                     "description": "Scaling for images."
                 },
                 "painting_imperwell": {
-                    "type": "string",
-                    "default": "unused",
+                    "type": "integer",
+                    "default": 80,
                     "description": "Number of images per well."
                 },
                 "painting_rows": {
@@ -182,7 +182,7 @@
             "properties": {
                 "barcoding_channame": {
                     "type": "string",
-                    "default": "DNA",
+                    "default": "DAPI",
                     "description": "Channel name for nucleus staining for barcoding arm."
                 },
                 "barcoding_illumapply_grouping": {
@@ -212,8 +212,8 @@
                     "description": "Scaling for images."
                 },
                 "barcoding_imperwell": {
-                    "type": "string",
-                    "default": "unused",
+                    "type": "integer",
+                    "default": 80,
                     "description": "Number of images per well."
                 },
                 "barcoding_rows": {
@@ -284,6 +284,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Whether to compress output files."
+                },
+                "phenix": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the images are from a Phenix microscope where the first image is in the center of the well"
                 }
             },
             "fa_icon": "fas fa-cog"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -213,7 +213,7 @@
                 },
                 "barcoding_imperwell": {
                     "type": "integer",
-                    "default": 80,
+                    "default": 20,
                     "description": "Number of images per well."
                 },
                 "barcoding_rows": {

--- a/subworkflows/local/barcoding/main.nf
+++ b/subworkflows/local/barcoding/main.nf
@@ -41,6 +41,7 @@ workflow BARCODING {
     barcoding_xoffset_tiles
     barcoding_yoffset_tiles
     compress
+    phenix
     barcoding_channame
     qc_barcoding_passed
 
@@ -360,6 +361,7 @@ workflow BARCODING {
         barcoding_xoffset_tiles,
         barcoding_yoffset_tiles,
         compress,
+        phenix,
         barcoding_channame,
         qc_barcoding_passed,
     )

--- a/subworkflows/local/cellpainting/main.nf
+++ b/subworkflows/local/cellpainting/main.nf
@@ -33,6 +33,7 @@ workflow CELLPAINTING {
     painting_xoffset_tiles
     painting_yoffset_tiles
     compress
+    phenix
     painting_channame
     qc_painting_passed
 
@@ -281,6 +282,7 @@ workflow CELLPAINTING {
         painting_xoffset_tiles,
         painting_yoffset_tiles,
         compress,
+        phenix,
         painting_channame,
         qc_painting_passed,
     )

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -63,7 +63,7 @@ nextflow_pipeline {
                 painting_round_or_square    = "square"
                 painting_quarter_if_round   = true
                 painting_overlap_pct        = 10
-                painting_imperwell          = "unused"
+                painting_imperwell          = 4
                 painting_rows               = 2
                 painting_columns            = 2
                 painting_stitchorder        = "Grid: snake by rows"
@@ -72,7 +72,7 @@ nextflow_pipeline {
                 barcoding_round_or_square   = "square"
                 barcoding_quarter_if_round  = true
                 barcoding_overlap_pct       = 10
-                barcoding_imperwell         = "unused"
+                barcoding_imperwell         = 4
                 barcoding_rows              = 2
                 barcoding_columns           = 2
                 barcoding_stitchorder       = "Grid: snake by rows"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -126,7 +126,7 @@ nextflow_pipeline {
                 input                       = "${projectDir}/assets/samplesheet.csv"
                 barcodes                    = "s3://nf-pooled-cellpainting-sandbox/data/test-data/fix-s1_sub25/Source1/workspace/metadata/Barcodes.csv"
                 range_skip                  = 2
-                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.test.py"
+                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.env_master.test_profile.py"
 
                 painting_illumcalc_cppipe   = "${projectDir}/assets/cellprofiler/painting_illumcalc_cppipe.template"
                 painting_illumapply_cppipe  = "${projectDir}/assets/cellprofiler/painting_illumapply.cppipe"
@@ -204,7 +204,7 @@ nextflow_pipeline {
                 input                       = "${projectDir}/assets/samplesheet.csv"
                 barcodes                    = "s3://nf-pooled-cellpainting-sandbox/data/test-data/fix-s1_sub25/Source1/workspace/metadata/Barcodes.csv"
                 range_skip                  = 2
-                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.test.py"
+                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.env_master.test_profile.py"
 
                 painting_illumcalc_cppipe   = "${projectDir}/assets/cellprofiler/painting_illumcalc_cppipe.template"
                 painting_illumapply_cppipe  = "${projectDir}/assets/cellprofiler/painting_illumapply.cppipe"
@@ -284,7 +284,7 @@ nextflow_pipeline {
                 input                       = "${projectDir}/assets/samplesheet.csv"
                 barcodes                    = "s3://nf-pooled-cellpainting-sandbox/data/test-data/fix-s1_sub25/Source1/workspace/metadata/Barcodes.csv"
                 range_skip                  = 2
-                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.test.py"
+                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.env_master.test_profile.py"
 
                 painting_illumcalc_cppipe   = "${projectDir}/assets/cellprofiler/painting_illumcalc_cppipe.template"
                 painting_illumapply_cppipe  = "${projectDir}/assets/cellprofiler/painting_illumapply.cppipe"
@@ -364,7 +364,7 @@ nextflow_pipeline {
                 input                       = "${projectDir}/assets/samplesheet.csv"
                 barcodes                    = "s3://nf-pooled-cellpainting-sandbox/data/test-data/fix-s1_sub25/Source1/workspace/metadata/Barcodes.csv"
                 range_skip                  = 2
-                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.test.py"
+                fiji_stitchcrop_script      = "${projectDir}/assets/stitchcrop/stitch_crop.env_master.test_profile.py"
 
                 painting_illumcalc_cppipe   = "${projectDir}/assets/cellprofiler/painting_illumcalc_cppipe.template"
                 painting_illumapply_cppipe  = "${projectDir}/assets/cellprofiler/painting_illumapply.cppipe"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -141,7 +141,7 @@ nextflow_pipeline {
                 painting_quarter_if_round   = true
                 painting_overlap_pct        = 10
                 painting_scalingstring      = 2
-                painting_imperwell          = "unused"
+                painting_imperwell          = 1
                 painting_rows               = 2
                 painting_columns            = 2
                 painting_stitchorder        = "Grid: snake by rows"
@@ -151,7 +151,7 @@ nextflow_pipeline {
                 barcoding_quarter_if_round  = true
                 barcoding_overlap_pct       = 10
                 barcoding_scalingstring     = 2
-                barcoding_imperwell         = "unused"
+                barcoding_imperwell         = 1
                 barcoding_rows              = 2
                 barcoding_columns           = 2
                 barcoding_stitchorder       = "Grid: snake by rows"
@@ -219,7 +219,7 @@ nextflow_pipeline {
                 painting_quarter_if_round   = true
                 painting_overlap_pct        = 10
                 painting_scalingstring      = 2
-                painting_imperwell          = "unused"
+                painting_imperwell          = 1
                 painting_rows               = 2
                 painting_columns            = 2
                 painting_stitchorder        = "Grid: snake by rows"
@@ -229,7 +229,7 @@ nextflow_pipeline {
                 barcoding_quarter_if_round  = true
                 barcoding_overlap_pct       = 10
                 barcoding_scalingstring     = 2
-                barcoding_imperwell         = "unused"
+                barcoding_imperwell         = 1
                 barcoding_rows              = 2
                 barcoding_columns           = 2
                 barcoding_stitchorder       = "Grid: snake by rows"
@@ -299,7 +299,7 @@ nextflow_pipeline {
                 painting_quarter_if_round   = true
                 painting_overlap_pct        = 10
                 painting_scalingstring      = 2
-                painting_imperwell          = "unused"
+                painting_imperwell          = 1
                 painting_rows               = 2
                 painting_columns            = 2
                 painting_stitchorder        = "Grid: snake by rows"
@@ -309,7 +309,7 @@ nextflow_pipeline {
                 barcoding_quarter_if_round  = true
                 barcoding_overlap_pct       = 10
                 barcoding_scalingstring     = 2
-                barcoding_imperwell         = "unused"
+                barcoding_imperwell         = 1
                 barcoding_rows              = 2
                 barcoding_columns           = 2
                 barcoding_stitchorder       = "Grid: snake by rows"
@@ -379,7 +379,7 @@ nextflow_pipeline {
                 painting_quarter_if_round   = true
                 painting_overlap_pct        = 10
                 painting_scalingstring      = 2
-                painting_imperwell          = "unused"
+                painting_imperwell          = 1
                 painting_rows               = 2
                 painting_columns            = 2
                 painting_stitchorder        = "Grid: snake by rows"
@@ -389,7 +389,7 @@ nextflow_pipeline {
                 barcoding_quarter_if_round  = true
                 barcoding_overlap_pct       = 10
                 barcoding_scalingstring     = 2
-                barcoding_imperwell         = "unused"
+                barcoding_imperwell         = 1
                 barcoding_rows              = 2
                 barcoding_columns           = 2
                 barcoding_stitchorder       = "Grid: snake by rows"

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -2114,6 +2114,7 @@
                 "workspace/qc_reports/7_preprocessing/Plate1/barcode_score_distribution_per_well.png",
                 "workspace/qc_reports/7_preprocessing/Plate1/library_nucleotide_frequency.png",
                 "workspace/qc_reports/7_preprocessing/Plate1/observed_nucleotide_frequency.png",
+                "workspace/qc_reports/7_preprocessing/Plate1/observed_nucleotide_frequency_noYlim.png",
                 "workspace/qc_reports/7_preprocessing/Plate1/spatial_quality_scatter.png",
                 "workspace/qc_reports/8_stitching_barcoding",
                 "workspace/qc_reports/8_stitching_barcoding/Plate1",

--- a/workflows/nf-pooled-cellpainting.nf
+++ b/workflows/nf-pooled-cellpainting.nf
@@ -74,6 +74,7 @@ workflow POOLED_CELLPAINTING {
         params.painting_xoffset_tiles,
         params.painting_yoffset_tiles,
         params.compress,
+        params.phenix,
         params.painting_channame,
         params.qc_painting_passed,
     )
@@ -108,6 +109,7 @@ workflow POOLED_CELLPAINTING {
         params.barcoding_xoffset_tiles,
         params.barcoding_yoffset_tiles,
         params.compress,
+        params.phenix,
         params.barcoding_channame,
         params.qc_barcoding_passed,
     )
@@ -161,7 +163,7 @@ workflow POOLED_CELLPAINTING {
                         // For barcoding, channels are typically 'DNA' and 'CycleXX'
                         // We need to infer the channel from the filename or assume a default if not explicitly in meta
                         // Assuming channel is part of the filename for barcoding as before, or could be passed in meta
-                        def barcode_match = (img.name =~ /Cycle(\d+)_([A-Z]+|DNA|DAPI)\.tiff?$/)
+                        def barcode_match = (img.name =~ /Cycle(\d+)_(A488|A568|A647|DNA|DAPI|[ACGT])(?:_Site_\d+)?\.tiff?$/)
                         if (barcode_match) {
                             img_meta.cycle = barcode_match[0][1] as Integer
                             img_meta.channel = barcode_match[0][2]


### PR DESCRIPTION
This PR builds on #57 so it should be merged first.
Supports running a Phenix acquisition end to end.
Overhauls FIJI stitch/crop script and adds handling of Phenix acquisition with first image in center of well.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/broadinstitute/nf-pooled-cellpainting/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
