### PR TITLE
🐛 fix(load-data-csv): correct single-channel detection for list channels

### DIFF
--- a/bin/generate_load_data_csv.py
+++ b/bin/generate_load_data_csv.py
@@ -430,20 +430,32 @@ def load_metadata_json(metadata_json_path: str) -> Dict:
         if 'arm' in first_entry:
             normalized_metadata['arm'] = first_entry['arm']
         if 'channels' in first_entry and first_entry['channels'] is not None:
+            # Dedupe in order of first appearance so downstream iteration
+            # (Frame_idx mapping, column order) is deterministic. `list(set(...))`
+            # randomizes per-process via PYTHONHASHSEED and broke the multi-channel
+            # discriminator below.
             if isinstance(first_entry['channels'], list):
                 channels_aggregated = []
                 for entry in metadata:
                     if isinstance(entry.get('channels'), list):
-                        channels_aggregated += entry['channels']
-                normalized_metadata['channels'] = list(set(channels_aggregated))
+                        for ch in entry['channels']:
+                            if ch not in channels_aggregated:
+                                channels_aggregated.append(ch)
+                normalized_metadata['channels'] = channels_aggregated
+                # Single-channel-per-entry mode means each entry contributes a
+                # different channel; compare as sets so original list order
+                # doesn't flip this flag.
+                single_channels_present = (
+                    set(normalized_metadata['channels']) != set(first_entry['channels'])
+                )
             elif isinstance(first_entry['channels'], str):
-                normalized_metadata['channels'] = ",".join(sorted(set(
-                    entry.get('channels')
-                    for entry in metadata
-                    if entry.get('channels') is not None
-                )))
-
-            single_channels_present = normalized_metadata['channels'] != first_entry['channels']
+                channels_seen = []
+                for entry in metadata:
+                    ch_str = entry.get('channels')
+                    if ch_str is not None and ch_str not in channels_seen:
+                        channels_seen.append(ch_str)
+                normalized_metadata['channels'] = ",".join(channels_seen)
+                single_channels_present = normalized_metadata['channels'] != first_entry['channels']
 
         # Detect cycles: if multiple unique cycles exist, create 'cycles' list
         # Otherwise use single 'cycle' value
@@ -519,8 +531,16 @@ def load_metadata_json(metadata_json_path: str) -> Dict:
             # Preserve channel if present (for single-channel images like segcheck)
             if 'channel' in entry:
                 metadata_entry['channel'] = str(entry['channel'])
-            elif single_channels_present:
-                metadata_entry['channel'] = str(entry['channels'])
+            elif single_channels_present and 'channels' in entry:
+                # Synthesize a singular `channel` from a single-element `channels`
+                # list/string. Multi-element lists are multi-channel files and
+                # must NOT be turned into a literal list-string here, which was
+                # the root cause of the KeyError 'DNA'/'CHN2' failures.
+                ch = entry['channels']
+                if isinstance(ch, list) and len(ch) == 1:
+                    metadata_entry['channel'] = str(ch[0])
+                elif isinstance(ch, str):
+                    metadata_entry['channel'] = ch
             result['image_metadata'].append(metadata_entry)
 
     # Extract optional fields
@@ -1239,11 +1259,13 @@ def generate_csv_rows(
                 # Multi-cycle multi-channel images - generate columns for each cycle
                 illum_by_cycle = file_data['illum'].get('_by_cycle', {})
 
-                # Get channels from JSON metadata (required!)
-                if metadata_json and 'channels' in metadata_json:
-                    channels_to_use = metadata_json['channels']
-                elif metadata_channels:
+                # CLI --channels overrides JSON (matches the "overriding JSON"
+                # log line emitted by main()); without this the override never
+                # reaches column generation.
+                if metadata_channels:
                     channels_to_use = metadata_channels
+                elif metadata_json and 'channels' in metadata_json:
+                    channels_to_use = metadata_json['channels']
                 else:
                     raise ValueError("Channels must be specified in JSON metadata or CLI args")
 
@@ -1296,11 +1318,13 @@ def generate_csv_rows(
             elif files_by_cycle:
                 illum_by_cycle = file_data['illum'].get('_by_cycle', {})
 
-                # Get channels from JSON metadata (required!)
-                if metadata_json and 'channels' in metadata_json:
-                    channels_to_use = metadata_json['channels']
-                elif metadata_channels:
+                # CLI --channels overrides JSON (matches the "overriding JSON"
+                # log line emitted by main()); without this the override never
+                # reaches column generation.
+                if metadata_channels:
                     channels_to_use = metadata_channels
+                elif metadata_json and 'channels' in metadata_json:
+                    channels_to_use = metadata_json['channels']
                 else:
                     raise ValueError("Channels must be specified in JSON metadata or CLI args")
 
@@ -1351,11 +1375,13 @@ def generate_csv_rows(
                 # Example: WellA1_PointA1_0000_ChannelDNA,Phalloidin,CHN2_Seq0000.ome.tiff
                 filename = file_data['images']['_file']
 
-                # Get channels from JSON metadata (required!)
-                if metadata_json and 'channels' in metadata_json:
-                    channels_to_use = metadata_json['channels']
-                elif metadata_channels:
+                # CLI --channels overrides JSON (matches the "overriding JSON"
+                # log line emitted by main()); without this the override never
+                # reaches column generation.
+                if metadata_channels:
                     channels_to_use = metadata_channels
+                elif metadata_json and 'channels' in metadata_json:
+                    channels_to_use = metadata_json['channels']
                 else:
                     raise ValueError("Channels must be specified in JSON metadata or CLI args")
 
@@ -1396,11 +1422,13 @@ def generate_csv_rows(
 
             # PATTERN 4: Single channel files for illum calc and apply, without cycles
             elif 'illum' in pipeline_type:
-                # Get channels from JSON metadata (required!)
-                if metadata_json and 'channels' in metadata_json:
-                    channels_to_use = metadata_json['channels']
-                elif metadata_channels:
+                # CLI --channels overrides JSON (matches the "overriding JSON"
+                # log line emitted by main()); without this the override never
+                # reaches column generation.
+                if metadata_channels:
                     channels_to_use = metadata_channels
+                elif metadata_json and 'channels' in metadata_json:
+                    channels_to_use = metadata_json['channels']
                 else:
                     raise ValueError("Channels must be specified in JSON metadata or CLI args")
 


### PR DESCRIPTION
## Summary

Fixes the `cellprofiler - illumapply - painting` test failure on shard 1/7 (failing since commit 679f545 first pulled it into CI selection; root cause introduced in b24364083 "Handle channels passed as lists").

`normalize_metadata_format` aggregated multi-entry `channels` lists via `list(set(...))`, then compared the result to `first_entry['channels']` with `!=`. `set` iteration order is randomized per process via `PYTHONHASHSEED`, so the comparison almost always flagged multi-channel data as single-channel; that synthesized a bogus `channel = str(entry['channels'])` (the literal Python list-string `"['Phalloidin', 'CHN2', 'DNA']"`) on every entry, which routed the file into the single-channel branch of `collect_and_group_files` and surfaced downstream as `KeyError: 'DNA'` (or 'CHN2', depending on hash seed) in PATTERN 4 of `generate_csv_rows`.

Three changes in `bin/generate_load_data_csv.py`:

- Dedupe `channels` in order of first appearance instead of via `set`, so the aggregated list is deterministic.
- Compare as sets when entries carry a list, so original list order doesn't flip `single_channels_present`.
- When synthesizing the singular `channel`, only do so for a real single-channel entry (one-element list or string) — never stringify a multi-channel list.

Also fixes PATTERN 1–4 in `generate_csv_rows` to honor `metadata_channels` (CLI `--channels`) over `metadata_json['channels']`. The previous precedence contradicted the "✓ Using CLI arg channels (overriding JSON)" log line and would mask future ordering bugs.

## Test plan

Verified locally with three Python-level reproducers against `bin/generate_load_data_csv.py`:

- [x] The exact failing CI input (4 sites, multi-channel OME-TIFFs, `channels:['Phalloidin','CHN2','DNA']` per entry) — generates 4 rows, deterministically across three consecutive runs.
- [x] Single-channel-per-entry (Phenix-style: one file per channel) — generates a row with correct `FileName_OrigCHN2/DAPI/Phalloidin` columns.
- [x] Multi-cycle barcoding (3 cycles × 4 channels) — generates `FileName_Cycle0N_Orig{A,C,G,T}` and `Frame_Cycle0N_Orig{A,C,G,T}` columns.
- [ ] CI nf-test on this branch (full `cellprofiler/illumapply/tests/main.nf.test` plus the rest of the change-selected suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)