### PR TITLE
🐛 fix: pin CellProfiler plugin URLs to immutable commit SHAs

### DIFF
--- a/docs/cellprofiler.md
+++ b/docs/cellprofiler.md
@@ -167,8 +167,8 @@ cellprofiler -c -r \\
 Default URLs are configured in `nextflow.config`:
 
 ```groovy
-callbarcodes_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/callbarcodes.py"
-compensatecolors_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/compensatecolors.py"
+callbarcodes_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/ad3d9c031b97a31f6300372baa378f75ecb44426/active_plugins/callbarcodes.py"
+compensatecolors_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/da969556d1d5095e5737601f483c7d55da374f75/active_plugins/compensatecolors.py"
 ```
 
 ## Output Organization

--- a/nextflow.config
+++ b/nextflow.config
@@ -83,8 +83,8 @@ params {
     cycle_metadata_name = "Cycle"
 
     // Cellprofiler plugins
-    callbarcodes_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/callbarcodes.py"
-    compensatecolors_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/compensatecolors.py"
+    callbarcodes_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/ad3d9c031b97a31f6300372baa378f75ecb44426/active_plugins/callbarcodes.py"
+    compensatecolors_plugin = "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/da969556d1d5095e5737601f483c7d55da374f75/active_plugins/compensatecolors.py"
 
     // MultiQC options
     multiqc_config = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -349,12 +349,12 @@
             "properties": {
                 "callbarcodes_plugin": {
                     "type": "string",
-                    "default": "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/callbarcodes.py",
+                    "default": "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/ad3d9c031b97a31f6300372baa378f75ecb44426/active_plugins/callbarcodes.py",
                     "description": "Cellprofiler plugin for calling barcodes."
                 },
                 "compensatecolors_plugin": {
                     "type": "string",
-                    "default": "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/refs/heads/master/active_plugins/compensatecolors.py",
+                    "default": "https://raw.githubusercontent.com/CellProfiler/CellProfiler-plugins/da969556d1d5095e5737601f483c7d55da374f75/active_plugins/compensatecolors.py",
                     "description": "Cellprofiler plugin for compensating colors."
                 }
             },


### PR DESCRIPTION
## What

Forward-port of the 1.0.1 reproducibility fix into `dev`.

Pins the `callbarcodes` and `compensatecolors` CellProfiler plugins to fixed commit SHAs instead of the mutable `refs/heads/master` branch:

- `callbarcodes.py` → `ad3d9c031b97a31f6300372baa378f75ecb44426`
- `compensatecolors.py` → `da969556d1d5095e5737601f483c7d55da374f75`

## Why

`dev` fetched these plugins from `master`. Because `master` is mutable, upstream edits silently change the plugin code staged at runtime, so runs are not reproducible. Pinning to a SHA freezes the exact plugin version.

## Files

- `nextflow.config` — param defaults
- `nextflow_schema.json` — schema defaults
- `docs/cellprofiler.md` — documented example

No pipeline logic or version bump; `dev` stays `1.1.0dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)